### PR TITLE
fix public deck ingress

### DIFF
--- a/clusters/prow/manifests/prow/01-deck-public.yaml
+++ b/clusters/prow/manifests/prow/01-deck-public.yaml
@@ -204,16 +204,16 @@ metadata:
 spec:
   tls:
     - hosts:
-        - '__PROW_DECK_PUBLIC_DOMAIN__'
+        - 'public-prow.kcp.k8c.io'
       secretName: deck-public-tls
   rules:
-    - host: '__PROW_DECK_PUBLIC_DOMAIN__'
+    - host: 'public-prow.kcp.k8c.io'
       http:
         paths:
           - path: /
             pathType: Prefix
             backend:
               service:
-                name: deck
+                name: deck-public
                 port:
                   number: 80

--- a/clusters/prow/manifests/prow/01-deck.yaml
+++ b/clusters/prow/manifests/prow/01-deck.yaml
@@ -171,7 +171,7 @@ spec:
                   name: deck-oauth-app
                   key: cookieSecret
             - name: OAUTH2_PROXY_COOKIE_DOMAIN
-              value: '__PROW_DECK_DOMAIN__'
+              value: 'prow.kcp.k8c.io'
             - name: OAUTH2_PROXY_COOKIE_NAME
               value: deck-kcp-k8c-io-oauth2-proxy
             - name: OAUTH2_PROXY_COOKIE_SAMESITE
@@ -240,10 +240,10 @@ metadata:
 spec:
   tls:
     - hosts:
-        - '__PROW_DECK_DOMAIN__'
+        - 'prow.kcp.k8c.io'
       secretName: deck-tls
   rules:
-    - host: '__PROW_DECK_DOMAIN__'
+    - host: 'prow.kcp.k8c.io'
       http:
         paths:
           - path: /

--- a/clusters/prow/manifests/prow/01-gcsweb-public.yaml
+++ b/clusters/prow/manifests/prow/01-gcsweb-public.yaml
@@ -76,7 +76,7 @@ metadata:
     ingress.kubernetes.io/force-ssl-redirect: "true"
 spec:
   rules:
-    - host: '__GCSWEB_PUBLIC_DOMAIN__'
+    - host: 'public-gcsweb.kcp.k8c.io'
       http:
         paths:
           - path: /
@@ -88,5 +88,5 @@ spec:
                   number: 80
   tls:
     - hosts:
-        - '__GCSWEB_PUBLIC_DOMAIN__'
+        - 'public-gcsweb.kcp.k8c.io'
       secretName: gcsweb-public-tls

--- a/clusters/prow/manifests/prow/01-gcsweb.yaml
+++ b/clusters/prow/manifests/prow/01-gcsweb.yaml
@@ -64,7 +64,7 @@ spec:
                   name: gcsweb-oauth-app
                   key: cookieSecret
             - name: OAUTH2_PROXY_COOKIE_DOMAIN
-              value: '__GCSWEB_DOMAIN__'
+              value: 'gcsweb.kcp.k8c.io'
             - name: OAUTH2_PROXY_COOKIE_NAME
               value: gcsweb-kcp-k8c-io-oauth2-proxy
             - name: OAUTH2_PROXY_COOKIE_SAMESITE
@@ -110,7 +110,7 @@ metadata:
     ingress.kubernetes.io/force-ssl-redirect: "true"
 spec:
   rules:
-    - host: '__GCSWEB_DOMAIN__'
+    - host: 'gcsweb.kcp.k8c.io'
       http:
         paths:
           - path: /
@@ -122,5 +122,5 @@ spec:
                   number: 80
   tls:
     - hosts:
-        - '__GCSWEB_DOMAIN__'
+        - 'gcsweb.kcp.k8c.io'
       secretName: gcsweb-tls

--- a/clusters/prow/manifests/prow/01-hook.yaml
+++ b/clusters/prow/manifests/prow/01-hook.yaml
@@ -178,10 +178,10 @@ metadata:
 spec:
   tls:
     - hosts:
-        - '__PROW_HOOK_DOMAIN__'
+        - 'prow.kcp.k8c.io'
       secretName: hook-tls
   rules:
-    - host: '__PROW_HOOK_DOMAIN__'
+    - host: 'prow.kcp.k8c.io'
       http:
         paths:
           - path: /hook


### PR DESCRIPTION
This fixes the wrong target service for the deck-public Ingress and also removes some accidental leftovers from when this might have turned into a Helm chart.