### PR TITLE
add kcp-dev/logicalcluster to Prow

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -14,10 +14,12 @@ plank:
   report_templates:
     '*': '[Full PR test history](https://prow.kcp.k8c.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}})'
     'kcp-dev/infra': '[Full PR test history](https://public-prow.kcp.k8c.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}})'
+    'kcp-dev/logicalcluster': '[Full PR test history](https://public-prow.kcp.k8c.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}})'
 
   job_url_prefix_config:
     '*': https://prow.kcp.k8c.io/view/
     'kcp-dev/infra': https://public-prow.kcp.k8c.io/view/
+    'kcp-dev/logicalcluster': https://public-prow.kcp.k8c.io/view/
 
   default_decoration_config_entries:
     # default config
@@ -35,6 +37,12 @@ plank:
         s3_credentials_secret: "s3-credentials-internal"
 
     - repo: "kcp-dev/infra"
+      config:
+        s3_credentials_secret: "s3-credentials-public"
+        gcs_configuration:
+          bucket: "s3://prow-public-data"
+
+    - repo: "kcp-dev/logicalcluster"
       config:
         s3_credentials_secret: "s3-credentials-public"
         gcs_configuration:
@@ -117,6 +125,7 @@ tide:
   queries:
     - repos:
         - kcp-dev/infra
+        - kcp-dev/logicalcluster
       labels:
         - lgtm
         - approved
@@ -135,12 +144,21 @@ branch-protection:
   orgs:
     kcp-dev:
       repos:
-        kcp:
+        infra:
           protect: true
           restrictions:
             users: []
             teams:
-              - kcp-dev/infra-maintainers
+              - kcp-dev/kcp-admins
+          include:
+            - "^main$"
+
+        logicalcluster:
+          protect: true
+          restrictions:
+            users: []
+            teams:
+              - kcp-dev/kcp-admins
           include:
             - "^main$"
 

--- a/prow/jobs/logicalcluster/logicalcluster-presubmits.yaml
+++ b/prow/jobs/logicalcluster/logicalcluster-presubmits.yaml
@@ -1,0 +1,21 @@
+presubmits:
+  kcp-dev/logicalcluster:
+    - name: pull-logicalcluster-validate-prow-yaml
+      always_run: true
+      decorate: true
+      clone_uri: "ssh://git@github.com/kcp-dev/logicalcluster.git"
+      extra_refs:
+        - org: kcp-dev
+          repo: infra
+          base_ref: main
+          clone_uri: git@github.com:kcp-dev/infra.git
+      spec:
+        containers:
+          - image: gcr.io/k8s-prow/checkconfig:v20230518-c802d8aea4
+            command:
+              - checkconfig
+            args:
+              - -plugin-config=/home/prow/go/src/github.com/kcp-dev/infra/prow/plugins.yaml
+              - -config-path=/home/prow/go/src/github.com/kcp-dev/infra/prow/config.yaml
+              - -job-config-path=/home/prow/go/src/github.com/kcp-dev/infra/prow/jobs
+              - -prow-yaml-repo-name=$(REPO_OWNER)/$(REPO_NAME)


### PR DESCRIPTION
kcp-dev/logicalcluster is the next repo we want to migrate to our prow.

I also could not find (see?) the infra-maintainers team, so I restricted the main branch to kcp-admins.