### PR TITLE
use regular merges in Prow by default

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -124,7 +124,7 @@ tide:
     '*': https://prow.kcp.k8c.io/pr
 
   merge_method:
-    kcp-dev: squash
+    kcp-dev: merge
 
   queries:
     - repos:


### PR DESCRIPTION
Popular opinion is on the side of regular merges, so this PR changes the merge strategy that Prow uses by default.