### PR TITLE
Deploy Prow automatically

### DIFF
--- a/clusters/build/hack/ci/deploy.sh
+++ b/clusters/build/hack/ci/deploy.sh
@@ -6,6 +6,11 @@ cd $(dirname $0)/../..
 source hack/settings.sh
 source hack/lib.sh
 
+if [ -n "${KUBE_CONTEXT:-}" ]; then
+  echo "Switching to $KUBE_CONTEXT context..."
+  kubectl config set-context "$KUBE_CONTEXT"
+fi
+
 ###########################################################
 # setup machines
 

--- a/clusters/prow/hack/ci/deploy.sh
+++ b/clusters/prow/hack/ci/deploy.sh
@@ -10,6 +10,11 @@ cd $(dirname $0)/../..
 source hack/settings.sh
 source hack/lib.sh
 
+if [ -n "${KUBE_CONTEXT:-}" ]; then
+  echo "Switching to $KUBE_CONTEXT context..."
+  kubectl config set-context "$KUBE_CONTEXT"
+fi
+
 ###########################################################
 # setup machines
 

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -195,3 +195,16 @@ presets:
           configMapKeyRef:
             name: cluster-config
             key: GOPROXY
+
+  ################################################################
+  # (prow-cluster only) mount the god kubeconfig
+
+  - labels:
+      preset-prow-kubeconfig: "true"
+    volumeMounts:
+      - name: prow-kubeconfig
+        mountPath: /etc/prow/kubeconfig
+    volumes:
+      - name: prow-kubeconfig
+        secret:
+          secretName: kubeconfig

--- a/prow/jobs/infra/infra-postsubmits.yaml
+++ b/prow/jobs/infra/infra-postsubmits.yaml
@@ -1,0 +1,37 @@
+presubmits:
+  kcp-dev/infra:
+    - name: post-infra-deploy-prow-cluster
+      run_if_changed: "clusters/prow/"
+      decorate: true
+      cluster: prow
+      clone_uri: "ssh://git@github.com/kcp-dev/infra.git"
+      labels:
+        preset-prow-kubeconfig: "true"
+      spec:
+        containers:
+          - image: quay.io/kubermatic/build:go-1.20-node-18-6
+            command:
+              - clusters/prow/hack/ci/deploy.sh
+            env:
+              - name: KUBECONFIG
+                value: /etc/prow/kubeconfig/kubeconfig
+              - name: KUBE_CONTEXT
+                value: prow
+
+    - name: post-infra-deploy-build-cluster
+      run_if_changed: "clusters/build/"
+      decorate: true
+      cluster: prow
+      clone_uri: "ssh://git@github.com/kcp-dev/infra.git"
+      labels:
+        preset-prow-kubeconfig: "true"
+      spec:
+        containers:
+          - image: quay.io/kubermatic/build:go-1.20-node-18-6
+            command:
+              - clusters/build/hack/ci/deploy.sh
+            env:
+              - name: KUBECONFIG
+                value: /etc/prow/kubeconfig/kubeconfig
+              - name: KUBE_CONTEXT
+                value: default

--- a/prow/jobs/infra/infra-presubmits.yaml
+++ b/prow/jobs/infra/infra-presubmits.yaml
@@ -6,7 +6,7 @@ presubmits:
       clone_uri: "ssh://git@github.com/kcp-dev/infra.git"
       spec:
         containers:
-          - image: gcr.io/k8s-prow/checkconfig:v20230518-c802d8aea4
+          - image: gcr.io/k8s-prow/checkconfig:v20230522-3eb206f68f
             command:
               - checkconfig
             args:
@@ -14,3 +14,20 @@ presubmits:
               - -config-path=/home/prow/go/src/github.com/kcp-dev/infra/prow/config.yaml
               - -job-config-path=/home/prow/go/src/github.com/kcp-dev/infra/prow/jobs
               - -prow-yaml-repo-name=$(REPO_OWNER)/$(REPO_NAME)
+
+    - name: pull-infra-validate-prow-jobs
+      decorate: true
+      clone_uri: "ssh://git@github.com/kcp-dev/infra.git"
+      run_if_changed: "prow/jobs/"
+      branches:
+        - ^main$
+      spec:
+        containers:
+          - image: gcr.io/k8s-prow/checkconfig:v20230522-3eb206f68f
+            command:
+              - checkconfig
+            args:
+              - -plugin-config=/home/prow/go/src/github.com/kcp-dev/infra/prow/plugins.yaml
+              - -config-path=/home/prow/go/src/github.com/kcp-dev/infra/prow/config.yaml
+              - -job-config-path=/home/prow/go/src/github.com/kcp-dev/infra/prow/jobs
+              - -strict

--- a/prow/jobs/logicalcluster/logicalcluster-presubmits.yaml
+++ b/prow/jobs/logicalcluster/logicalcluster-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
           clone_uri: git@github.com:kcp-dev/infra.git
       spec:
         containers:
-          - image: gcr.io/k8s-prow/checkconfig:v20230518-c802d8aea4
+          - image: gcr.io/k8s-prow/checkconfig:v20230522-3eb206f68f
             command:
               - checkconfig
             args:

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -23,6 +23,19 @@ lgtm:
     # preserves lgtm on rebase or squash
     store_tree_hash: true
 
+# config_updater will automatically update the config configmap when config.yaml changes
+config_updater:
+  maps:
+    prow/config.yaml:
+      name: config
+    prow/plugins.yaml:
+      name: plugins
+    prow/jobs/**/*.yaml:
+      name: job-config
+      # makes it so we can have "jobs/kubermatic/presubmits.yaml" and "jobs/dashboard/presubmits.yaml"
+      # without naming conflicts (by default, Prow would use just the basename)
+      use_full_path_as_key: true
+
 cherry_pick_unapproved:
   branchregexp: "^release.*$"
   comment: |


### PR DESCRIPTION
This PR adds two new postsubmits to automatically deploy the Prow / Build clusters. Prow's configuration (config.yaml, plugin.yaml) are updated by Prow itself, so there doesn't need to be a job to apply those.