### PR TITLE
fix context switching in deployment scripts

### DIFF
--- a/clusters/build/hack/ci/deploy.sh
+++ b/clusters/build/hack/ci/deploy.sh
@@ -3,12 +3,12 @@
 set -euo pipefail
 
 cd $(dirname $0)/../..
+source ../../hack/lib.sh
 source hack/settings.sh
 source hack/lib.sh
 
 if [ -n "${KUBE_CONTEXT:-}" ]; then
-  echo "Switching to $KUBE_CONTEXT context..."
-  kubectl config set-context "$KUBE_CONTEXT"
+  use_tmp_kubeconfig_context "$KUBE_CONTEXT"
 fi
 
 ###########################################################

--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -1,0 +1,27 @@
+use_tmp_kubeconfig_context() {
+  context="$1"
+  echo "Switching to $context context..."
+
+  # creating a temporary file because some kubeconfigs might be mounted
+  # from Secrets and would be therefore read-only
+  tmpKubeconfig=$(mktemp)
+  cp "$KUBECONFIG" "$tmpKubeconfig"
+
+  export "KUBECONFIG=$tmpKubeconfig"
+  kubectl config use-context "$context"
+}
+
+deploy_helm_chart() {
+  local namespace="$1"
+  local release="$2"
+  local chart="$3"
+  local version="$4"
+  local valuesFile="$5"
+
+  helm --namespace "$namespace" upgrade \
+    --install \
+    --create-namespace \
+    --values "$valuesFile" \
+    --version $version \
+    "$release" "$chart"
+}


### PR DESCRIPTION
Changing the kubeconfig's context doesn't work on read-only volumes mounted from secrets.