### PR TITLE
fix deck-public service

### DIFF
--- a/clusters/prow/manifests/prow/01-deck-public.yaml
+++ b/clusters/prow/manifests/prow/01-deck-public.yaml
@@ -180,7 +180,7 @@ metadata:
   name: deck-public
 spec:
   selector:
-    app: deck
+    app: deck-public
   ports:
     - name: main
       port: 80


### PR DESCRIPTION
Make sure https://public-prow.kcp.k8c.io/ points to the correct service