### PR TITLE
prow/config: add branch protection by default to all repos

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -159,6 +159,17 @@ tide:
 branch-protection:
   orgs:
     kcp-dev:
+      protect: true
+      required_status_checks:
+        contexts:
+        - dco
+      restrictions:
+        users: []
+        teams:
+          - kcp-dev/kcp-admins
+      include:
+        - "^main$"
+
       repos:
         infra:
           protect: true


### PR DESCRIPTION
Fixes #16 

This sets up branch protection for all repos in kcp-dev.

/assign @xrstf 