### PR TITLE
prow/jobs/infra: fix label-sync jobs

### DIFF
--- a/prow/jobs/infra/infra-periodics.yaml
+++ b/prow/jobs/infra/infra-periodics.yaml
@@ -17,7 +17,7 @@ periodics:
         command:
         - label_sync
         args:
-        - --config=/etc/config/labels.yaml
+        - --config=/home/prow/go/src/github.com/kcp-dev/infra/prow/labels.yaml
         - --confirm=true
         - --orgs=kcp-dev
         - --token=/etc/oauth-token/secret
@@ -28,13 +28,7 @@ periodics:
         - name: oauth-token
           mountPath: /etc/oauth-token
           readOnly: true
-        - name: config
-          mountPath: /etc/config
-          readOnly: true
       volumes:
       - name: oauth-token
         secret:
           secretName: github-token
-      - name: config
-        configMap:
-          name: label-config

--- a/prow/jobs/infra/infra-presubmits.yaml
+++ b/prow/jobs/infra/infra-presubmits.yaml
@@ -45,7 +45,7 @@ presubmits:
           command:
           - label_sync
           args:
-          - --config=/etc/config/labels.yaml
+          - --config=/home/prow/go/src/github.com/kcp-dev/infra/prow/labels.yaml
           - --orgs=kcp-dev
           - --token=/etc/oauth-token/secret
           - --endpoint=http://ghproxy.prow.svc.cluster.local
@@ -55,13 +55,8 @@ presubmits:
           - name: oauth-token
             mountPath: /etc/oauth-token
             readOnly: true
-          - name: config
-            mountPath: /etc/config
-            readOnly: true
         volumes:
         - name: oauth-token
           secret:
             secretName: github-token
-        - name: config
-          configMap:
-            name: label-config
+


### PR DESCRIPTION
The `label-config` configmap is in the prow namespace and the prowjob runs in the default namespace.

Let's avoid using a configmap altogether and derive `labels.yaml` from the cloned infra repo.