### PR TITLE
add all remaining kcp-dev repositories to prow

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -13,13 +13,39 @@ plank:
 
   report_templates:
     '*': '[Full PR test history](https://prow.kcp.k8c.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}})'
+    'kcp-dev/apiextensions-apiserver': '[Full PR test history](https://public-prow.kcp.k8c.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}})'
+    'kcp-dev/apimachinery': '[Full PR test history](https://public-prow.kcp.k8c.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}})'
+    'kcp-dev/awesome-kcp': '[Full PR test history](https://public-prow.kcp.k8c.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}})'
+    'kcp-dev/client-go': '[Full PR test history](https://public-prow.kcp.k8c.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}})'
+    'kcp-dev/code-generator': '[Full PR test history](https://public-prow.kcp.k8c.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}})'
+    'kcp-dev/controller-runtime': '[Full PR test history](https://public-prow.kcp.k8c.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}})'
+    'kcp-dev/controller-runtime-example': '[Full PR test history](https://public-prow.kcp.k8c.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}})'
+    'kcp-dev/enhancements': '[Full PR test history](https://public-prow.kcp.k8c.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}})'
+    'kcp-dev/friends': '[Full PR test history](https://public-prow.kcp.k8c.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}})'
+    'kcp-dev/helm-charts': '[Full PR test history](https://public-prow.kcp.k8c.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}})'
     'kcp-dev/infra': '[Full PR test history](https://public-prow.kcp.k8c.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}})'
+    'kcp-dev/kcp': '[Full PR test history](https://public-prow.kcp.k8c.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}})'
+    'kcp-dev/kcp-dev.github.io': '[Full PR test history](https://public-prow.kcp.k8c.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}})'
+    'kcp-dev/kcp.io': '[Full PR test history](https://public-prow.kcp.k8c.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}})'
     'kcp-dev/logicalcluster': '[Full PR test history](https://public-prow.kcp.k8c.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}})'
 
   job_url_prefix_config:
     '*': https://prow.kcp.k8c.io/view/
-    'kcp-dev/infra': https://public-prow.kcp.k8c.io/view/
-    'kcp-dev/logicalcluster': https://public-prow.kcp.k8c.io/view/
+    'kcp-dev/apiextensions-apiserver': 'https://public-prow.kcp.k8c.io/view/'
+    'kcp-dev/apimachinery': 'https://public-prow.kcp.k8c.io/view/'
+    'kcp-dev/awesome-kcp': 'https://public-prow.kcp.k8c.io/view/'
+    'kcp-dev/client-go': 'https://public-prow.kcp.k8c.io/view/'
+    'kcp-dev/code-generator': 'https://public-prow.kcp.k8c.io/view/'
+    'kcp-dev/controller-runtime': 'https://public-prow.kcp.k8c.io/view/'
+    'kcp-dev/controller-runtime-example': 'https://public-prow.kcp.k8c.io/view/'
+    'kcp-dev/enhancements': 'https://public-prow.kcp.k8c.io/view/'
+    'kcp-dev/friends': 'https://public-prow.kcp.k8c.io/view/'
+    'kcp-dev/helm-charts': 'https://public-prow.kcp.k8c.io/view/'
+    'kcp-dev/infra': 'https://public-prow.kcp.k8c.io/view/'
+    'kcp-dev/kcp': 'https://public-prow.kcp.k8c.io/view/'
+    'kcp-dev/kcp-dev.github.io': 'https://public-prow.kcp.k8c.io/view/'
+    'kcp-dev/kcp.io': 'https://public-prow.kcp.k8c.io/view/'
+    'kcp-dev/logicalcluster': 'https://public-prow.kcp.k8c.io/view/'
 
   default_decoration_config_entries:
     # default config
@@ -40,12 +66,76 @@ plank:
         ssh_host_fingerprints:
           - github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=
 
+    - repo: "kcp-dev/apiextensions-apiserver"
+      config:
+        s3_credentials_secret: "s3-credentials-public"
+        gcs_configuration:
+          bucket: "s3://prow-public-data"
+    - repo: "kcp-dev/apimachinery"
+      config:
+        s3_credentials_secret: "s3-credentials-public"
+        gcs_configuration:
+          bucket: "s3://prow-public-data"
+    - repo: "kcp-dev/awesome-kcp"
+      config:
+        s3_credentials_secret: "s3-credentials-public"
+        gcs_configuration:
+          bucket: "s3://prow-public-data"
+    - repo: "kcp-dev/client-go"
+      config:
+        s3_credentials_secret: "s3-credentials-public"
+        gcs_configuration:
+          bucket: "s3://prow-public-data"
+    - repo: "kcp-dev/code-generator"
+      config:
+        s3_credentials_secret: "s3-credentials-public"
+        gcs_configuration:
+          bucket: "s3://prow-public-data"
+    - repo: "kcp-dev/controller-runtime"
+      config:
+        s3_credentials_secret: "s3-credentials-public"
+        gcs_configuration:
+          bucket: "s3://prow-public-data"
+    - repo: "kcp-dev/controller-runtime-example"
+      config:
+        s3_credentials_secret: "s3-credentials-public"
+        gcs_configuration:
+          bucket: "s3://prow-public-data"
+    - repo: "kcp-dev/enhancements"
+      config:
+        s3_credentials_secret: "s3-credentials-public"
+        gcs_configuration:
+          bucket: "s3://prow-public-data"
+    - repo: "kcp-dev/friends"
+      config:
+        s3_credentials_secret: "s3-credentials-public"
+        gcs_configuration:
+          bucket: "s3://prow-public-data"
+    - repo: "kcp-dev/helm-charts"
+      config:
+        s3_credentials_secret: "s3-credentials-public"
+        gcs_configuration:
+          bucket: "s3://prow-public-data"
     - repo: "kcp-dev/infra"
       config:
         s3_credentials_secret: "s3-credentials-public"
         gcs_configuration:
           bucket: "s3://prow-public-data"
-
+    - repo: "kcp-dev/kcp"
+      config:
+        s3_credentials_secret: "s3-credentials-public"
+        gcs_configuration:
+          bucket: "s3://prow-public-data"
+    - repo: "kcp-dev/kcp-dev.github.io"
+      config:
+        s3_credentials_secret: "s3-credentials-public"
+        gcs_configuration:
+          bucket: "s3://prow-public-data"
+    - repo: "kcp-dev/kcp.io"
+      config:
+        s3_credentials_secret: "s3-credentials-public"
+        gcs_configuration:
+          bucket: "s3://prow-public-data"
     - repo: "kcp-dev/logicalcluster"
       config:
         s3_credentials_secret: "s3-credentials-public"
@@ -129,7 +219,19 @@ tide:
   queries:
     # no release notes
     - repos:
+        - kcp-dev/apiextensions-apiserver
+        - kcp-dev/apimachinery
+        - kcp-dev/awesome-kcp
+        - kcp-dev/client-go
+        - kcp-dev/code-generator
+        - kcp-dev/controller-runtime
+        - kcp-dev/controller-runtime-example
+        - kcp-dev/enhancements
+        - kcp-dev/friends
+        - kcp-dev/helm-charts
         - kcp-dev/infra
+        - kcp-dev/kcp-dev.github.io
+        - kcp-dev/kcp.io
       labels:
         - lgtm
         - approved
@@ -143,6 +245,7 @@ tide:
 
     # with release notes
     - repos:
+        - kcp-dev/kcp
         - kcp-dev/logicalcluster
       labels:
         - lgtm
@@ -169,25 +272,6 @@ branch-protection:
           - kcp-dev/kcp-admins
       include:
         - "^main$"
-
-      repos:
-        infra:
-          protect: true
-          restrictions:
-            users: []
-            teams:
-              - kcp-dev/kcp-admins
-          include:
-            - "^main$"
-
-        logicalcluster:
-          protect: true
-          restrictions:
-            users: []
-            teams:
-              - kcp-dev/kcp-admins
-          include:
-            - "^main$"
 
 presets:
   ################################################################

--- a/prow/jobs/apiextensions-apiserver/apiextensions-apiserver-presubmits.yaml
+++ b/prow/jobs/apiextensions-apiserver/apiextensions-apiserver-presubmits.yaml
@@ -1,0 +1,21 @@
+presubmits:
+  kcp-dev/apiextensions-apiserver:
+    - name: pull-apiextensions-apiserver-validate-prow-yaml
+      always_run: true
+      decorate: true
+      clone_uri: "ssh://git@github.com/kcp-dev/apiextensions-apiserver.git"
+      extra_refs:
+        - org: kcp-dev
+          repo: infra
+          base_ref: main
+          clone_uri: git@github.com:kcp-dev/infra.git
+      spec:
+        containers:
+          - image: gcr.io/k8s-prow/checkconfig:v20230522-3eb206f68f
+            command:
+              - checkconfig
+            args:
+              - -plugin-config=/home/prow/go/src/github.com/kcp-dev/infra/prow/plugins.yaml
+              - -config-path=/home/prow/go/src/github.com/kcp-dev/infra/prow/config.yaml
+              - -job-config-path=/home/prow/go/src/github.com/kcp-dev/infra/prow/jobs
+              - -prow-yaml-repo-name=$(REPO_OWNER)/$(REPO_NAME)

--- a/prow/jobs/apimachinery/apimachinery-presubmits.yaml
+++ b/prow/jobs/apimachinery/apimachinery-presubmits.yaml
@@ -1,0 +1,21 @@
+presubmits:
+  kcp-dev/apimachinery:
+    - name: pull-apimachinery-validate-prow-yaml
+      always_run: true
+      decorate: true
+      clone_uri: "ssh://git@github.com/kcp-dev/apimachinery.git"
+      extra_refs:
+        - org: kcp-dev
+          repo: infra
+          base_ref: main
+          clone_uri: git@github.com:kcp-dev/infra.git
+      spec:
+        containers:
+          - image: gcr.io/k8s-prow/checkconfig:v20230522-3eb206f68f
+            command:
+              - checkconfig
+            args:
+              - -plugin-config=/home/prow/go/src/github.com/kcp-dev/infra/prow/plugins.yaml
+              - -config-path=/home/prow/go/src/github.com/kcp-dev/infra/prow/config.yaml
+              - -job-config-path=/home/prow/go/src/github.com/kcp-dev/infra/prow/jobs
+              - -prow-yaml-repo-name=$(REPO_OWNER)/$(REPO_NAME)

--- a/prow/jobs/awesome-kcp/awesome-kcp-presubmits.yaml
+++ b/prow/jobs/awesome-kcp/awesome-kcp-presubmits.yaml
@@ -1,0 +1,21 @@
+presubmits:
+  kcp-dev/awesome-kcp:
+    - name: pull-awesome-kcp-validate-prow-yaml
+      always_run: true
+      decorate: true
+      clone_uri: "ssh://git@github.com/kcp-dev/awesome-kcp.git"
+      extra_refs:
+        - org: kcp-dev
+          repo: infra
+          base_ref: main
+          clone_uri: git@github.com:kcp-dev/infra.git
+      spec:
+        containers:
+          - image: gcr.io/k8s-prow/checkconfig:v20230522-3eb206f68f
+            command:
+              - checkconfig
+            args:
+              - -plugin-config=/home/prow/go/src/github.com/kcp-dev/infra/prow/plugins.yaml
+              - -config-path=/home/prow/go/src/github.com/kcp-dev/infra/prow/config.yaml
+              - -job-config-path=/home/prow/go/src/github.com/kcp-dev/infra/prow/jobs
+              - -prow-yaml-repo-name=$(REPO_OWNER)/$(REPO_NAME)

--- a/prow/jobs/client-go/client-go-presubmits.yaml
+++ b/prow/jobs/client-go/client-go-presubmits.yaml
@@ -1,0 +1,21 @@
+presubmits:
+  kcp-dev/client-go:
+    - name: pull-client-go-validate-prow-yaml
+      always_run: true
+      decorate: true
+      clone_uri: "ssh://git@github.com/kcp-dev/client-go.git"
+      extra_refs:
+        - org: kcp-dev
+          repo: infra
+          base_ref: main
+          clone_uri: git@github.com:kcp-dev/infra.git
+      spec:
+        containers:
+          - image: gcr.io/k8s-prow/checkconfig:v20230522-3eb206f68f
+            command:
+              - checkconfig
+            args:
+              - -plugin-config=/home/prow/go/src/github.com/kcp-dev/infra/prow/plugins.yaml
+              - -config-path=/home/prow/go/src/github.com/kcp-dev/infra/prow/config.yaml
+              - -job-config-path=/home/prow/go/src/github.com/kcp-dev/infra/prow/jobs
+              - -prow-yaml-repo-name=$(REPO_OWNER)/$(REPO_NAME)

--- a/prow/jobs/code-generator/code-generator-presubmits.yaml
+++ b/prow/jobs/code-generator/code-generator-presubmits.yaml
@@ -1,0 +1,21 @@
+presubmits:
+  kcp-dev/code-generator:
+    - name: pull-code-generator-validate-prow-yaml
+      always_run: true
+      decorate: true
+      clone_uri: "ssh://git@github.com/kcp-dev/code-generator.git"
+      extra_refs:
+        - org: kcp-dev
+          repo: infra
+          base_ref: main
+          clone_uri: git@github.com:kcp-dev/infra.git
+      spec:
+        containers:
+          - image: gcr.io/k8s-prow/checkconfig:v20230522-3eb206f68f
+            command:
+              - checkconfig
+            args:
+              - -plugin-config=/home/prow/go/src/github.com/kcp-dev/infra/prow/plugins.yaml
+              - -config-path=/home/prow/go/src/github.com/kcp-dev/infra/prow/config.yaml
+              - -job-config-path=/home/prow/go/src/github.com/kcp-dev/infra/prow/jobs
+              - -prow-yaml-repo-name=$(REPO_OWNER)/$(REPO_NAME)

--- a/prow/jobs/controller-runtime-example/controller-runtime-example-presubmits.yaml
+++ b/prow/jobs/controller-runtime-example/controller-runtime-example-presubmits.yaml
@@ -1,0 +1,21 @@
+presubmits:
+  kcp-dev/controller-runtime-example:
+    - name: pull-controller-runtime-example-validate-prow-yaml
+      always_run: true
+      decorate: true
+      clone_uri: "ssh://git@github.com/kcp-dev/controller-runtime-example.git"
+      extra_refs:
+        - org: kcp-dev
+          repo: infra
+          base_ref: main
+          clone_uri: git@github.com:kcp-dev/infra.git
+      spec:
+        containers:
+          - image: gcr.io/k8s-prow/checkconfig:v20230522-3eb206f68f
+            command:
+              - checkconfig
+            args:
+              - -plugin-config=/home/prow/go/src/github.com/kcp-dev/infra/prow/plugins.yaml
+              - -config-path=/home/prow/go/src/github.com/kcp-dev/infra/prow/config.yaml
+              - -job-config-path=/home/prow/go/src/github.com/kcp-dev/infra/prow/jobs
+              - -prow-yaml-repo-name=$(REPO_OWNER)/$(REPO_NAME)

--- a/prow/jobs/controller-runtime/controller-runtime-presubmits.yaml
+++ b/prow/jobs/controller-runtime/controller-runtime-presubmits.yaml
@@ -1,0 +1,21 @@
+presubmits:
+  kcp-dev/controller-runtime:
+    - name: pull-controller-runtime-validate-prow-yaml
+      always_run: true
+      decorate: true
+      clone_uri: "ssh://git@github.com/kcp-dev/controller-runtime.git"
+      extra_refs:
+        - org: kcp-dev
+          repo: infra
+          base_ref: main
+          clone_uri: git@github.com:kcp-dev/infra.git
+      spec:
+        containers:
+          - image: gcr.io/k8s-prow/checkconfig:v20230522-3eb206f68f
+            command:
+              - checkconfig
+            args:
+              - -plugin-config=/home/prow/go/src/github.com/kcp-dev/infra/prow/plugins.yaml
+              - -config-path=/home/prow/go/src/github.com/kcp-dev/infra/prow/config.yaml
+              - -job-config-path=/home/prow/go/src/github.com/kcp-dev/infra/prow/jobs
+              - -prow-yaml-repo-name=$(REPO_OWNER)/$(REPO_NAME)

--- a/prow/jobs/enhancements/enhancements-presubmits.yaml
+++ b/prow/jobs/enhancements/enhancements-presubmits.yaml
@@ -1,0 +1,21 @@
+presubmits:
+  kcp-dev/enhancements:
+    - name: pull-enhancements-validate-prow-yaml
+      always_run: true
+      decorate: true
+      clone_uri: "ssh://git@github.com/kcp-dev/enhancements.git"
+      extra_refs:
+        - org: kcp-dev
+          repo: infra
+          base_ref: main
+          clone_uri: git@github.com:kcp-dev/infra.git
+      spec:
+        containers:
+          - image: gcr.io/k8s-prow/checkconfig:v20230522-3eb206f68f
+            command:
+              - checkconfig
+            args:
+              - -plugin-config=/home/prow/go/src/github.com/kcp-dev/infra/prow/plugins.yaml
+              - -config-path=/home/prow/go/src/github.com/kcp-dev/infra/prow/config.yaml
+              - -job-config-path=/home/prow/go/src/github.com/kcp-dev/infra/prow/jobs
+              - -prow-yaml-repo-name=$(REPO_OWNER)/$(REPO_NAME)

--- a/prow/jobs/friends/friends-presubmits.yaml
+++ b/prow/jobs/friends/friends-presubmits.yaml
@@ -1,0 +1,21 @@
+presubmits:
+  kcp-dev/friends:
+    - name: pull-friends-validate-prow-yaml
+      always_run: true
+      decorate: true
+      clone_uri: "ssh://git@github.com/kcp-dev/friends.git"
+      extra_refs:
+        - org: kcp-dev
+          repo: infra
+          base_ref: main
+          clone_uri: git@github.com:kcp-dev/infra.git
+      spec:
+        containers:
+          - image: gcr.io/k8s-prow/checkconfig:v20230522-3eb206f68f
+            command:
+              - checkconfig
+            args:
+              - -plugin-config=/home/prow/go/src/github.com/kcp-dev/infra/prow/plugins.yaml
+              - -config-path=/home/prow/go/src/github.com/kcp-dev/infra/prow/config.yaml
+              - -job-config-path=/home/prow/go/src/github.com/kcp-dev/infra/prow/jobs
+              - -prow-yaml-repo-name=$(REPO_OWNER)/$(REPO_NAME)

--- a/prow/jobs/helm-charts/helm-charts-presubmits.yaml
+++ b/prow/jobs/helm-charts/helm-charts-presubmits.yaml
@@ -1,0 +1,21 @@
+presubmits:
+  kcp-dev/helm-charts:
+    - name: pull-helm-charts-validate-prow-yaml
+      always_run: true
+      decorate: true
+      clone_uri: "ssh://git@github.com/kcp-dev/helm-charts.git"
+      extra_refs:
+        - org: kcp-dev
+          repo: infra
+          base_ref: main
+          clone_uri: git@github.com:kcp-dev/infra.git
+      spec:
+        containers:
+          - image: gcr.io/k8s-prow/checkconfig:v20230522-3eb206f68f
+            command:
+              - checkconfig
+            args:
+              - -plugin-config=/home/prow/go/src/github.com/kcp-dev/infra/prow/plugins.yaml
+              - -config-path=/home/prow/go/src/github.com/kcp-dev/infra/prow/config.yaml
+              - -job-config-path=/home/prow/go/src/github.com/kcp-dev/infra/prow/jobs
+              - -prow-yaml-repo-name=$(REPO_OWNER)/$(REPO_NAME)

--- a/prow/jobs/kcp-dev.github.io/kcp-dev.github.io-presubmits.yaml
+++ b/prow/jobs/kcp-dev.github.io/kcp-dev.github.io-presubmits.yaml
@@ -1,0 +1,21 @@
+presubmits:
+  kcp-dev/kcp-dev.github.io:
+    - name: pull-kcp-dev-github-io-validate-prow-yaml
+      always_run: true
+      decorate: true
+      clone_uri: "ssh://git@github.com/kcp-dev/kcp-dev.github.io.git"
+      extra_refs:
+        - org: kcp-dev
+          repo: infra
+          base_ref: main
+          clone_uri: git@github.com:kcp-dev/infra.git
+      spec:
+        containers:
+          - image: gcr.io/k8s-prow/checkconfig:v20230522-3eb206f68f
+            command:
+              - checkconfig
+            args:
+              - -plugin-config=/home/prow/go/src/github.com/kcp-dev/infra/prow/plugins.yaml
+              - -config-path=/home/prow/go/src/github.com/kcp-dev/infra/prow/config.yaml
+              - -job-config-path=/home/prow/go/src/github.com/kcp-dev/infra/prow/jobs
+              - -prow-yaml-repo-name=$(REPO_OWNER)/$(REPO_NAME)

--- a/prow/jobs/kcp.io/kcp.io-presubmits.yaml
+++ b/prow/jobs/kcp.io/kcp.io-presubmits.yaml
@@ -1,0 +1,21 @@
+presubmits:
+  kcp-dev/kcp.io:
+    - name: pull-kcp-io-validate-prow-yaml
+      always_run: true
+      decorate: true
+      clone_uri: "ssh://git@github.com/kcp-dev/kcp.io.git"
+      extra_refs:
+        - org: kcp-dev
+          repo: infra
+          base_ref: main
+          clone_uri: git@github.com:kcp-dev/infra.git
+      spec:
+        containers:
+          - image: gcr.io/k8s-prow/checkconfig:v20230522-3eb206f68f
+            command:
+              - checkconfig
+            args:
+              - -plugin-config=/home/prow/go/src/github.com/kcp-dev/infra/prow/plugins.yaml
+              - -config-path=/home/prow/go/src/github.com/kcp-dev/infra/prow/config.yaml
+              - -job-config-path=/home/prow/go/src/github.com/kcp-dev/infra/prow/jobs
+              - -prow-yaml-repo-name=$(REPO_OWNER)/$(REPO_NAME)

--- a/prow/jobs/kcp/kcp-presubmits.yaml
+++ b/prow/jobs/kcp/kcp-presubmits.yaml
@@ -1,0 +1,21 @@
+presubmits:
+  kcp-dev/kcp:
+    - name: pull-kcp-validate-prow-yaml
+      always_run: true
+      decorate: true
+      clone_uri: "ssh://git@github.com/kcp-dev/kcp.git"
+      extra_refs:
+        - org: kcp-dev
+          repo: infra
+          base_ref: main
+          clone_uri: git@github.com:kcp-dev/infra.git
+      spec:
+        containers:
+          - image: gcr.io/k8s-prow/checkconfig:v20230522-3eb206f68f
+            command:
+              - checkconfig
+            args:
+              - -plugin-config=/home/prow/go/src/github.com/kcp-dev/infra/prow/plugins.yaml
+              - -config-path=/home/prow/go/src/github.com/kcp-dev/infra/prow/config.yaml
+              - -job-config-path=/home/prow/go/src/github.com/kcp-dev/infra/prow/jobs
+              - -prow-yaml-repo-name=$(REPO_OWNER)/$(REPO_NAME)


### PR DESCRIPTION
This adds all remaining repos to the Prow config, setting up boilerplate verify-yaml jobs for all of them.

Only kcp and logicalcluster repos make use of the release-note plugin, but even that might go away (not sure exactly how changelogs are built in kcp yet).

I also removed the explicit branchprotection rules, as we now have an org-wide setting that seems identical.

part of #25