### PR TITLE
🌱  use GitHub Actions to build an image usable for Prow jobs

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -10,12 +10,6 @@ on:
     paths:
       - "images/build/*"
       - ".github/workflows/build-image.yaml"
-  pull_request:
-    branches:
-      - main
-    paths:
-      - "images/build/*"
-      - ".github/workflows/build-image.yaml"
 
 jobs:
   build:

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -1,0 +1,57 @@
+name: Build and Publish CI image
+
+permissions:
+  packages: write
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "images/build/*"
+      - ".github/workflows/build-image.yaml"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "images/build/*"
+      - ".github/workflows/build-image.yaml"
+
+jobs:
+  build:
+    if: github.repository_owner == 'kcp-dev'
+    name: Build CI Image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Docker Metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ghcr.io/${{ github.repository_owner }}/infra/build
+          tags: |
+            type=semver,pattern={{version}},value=v1.19.9-1
+
+      - name: Build and Push
+        uses: docker/build-push-action@v4
+        with:
+          context: "{{defaultContext}}:images/build"
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64
+          cache-from: type=gha,scope=${{ github.ref_name }}-buildx
+          cache-to: type=gha,scope=${{ github.ref_name }}-buildx,mode=max
+          build-args: GO_VERSION=1.19.9,K8S_VERSION=1.26.3

--- a/images/build/Dockerfile
+++ b/images/build/Dockerfile
@@ -1,0 +1,24 @@
+ARG GO_VERSION
+
+FROM docker.io/library/golang:${GO_VERSION} as download
+
+# this needs to be separate from the GO_VERSION arg above because otherwise
+# it is not in scope for usage in the RUN instructions below.
+ARG K8S_VERSION
+
+WORKDIR /tmp
+
+RUN curl --fail -Lo kubectl https://dl.k8s.io/release/v${K8S_VERSION}/bin/linux/amd64/kubectl && \
+    chmod +x kubectl && \
+    ./kubectl version --short --client
+
+FROM docker.io/library/golang:${GO_VERSION}
+
+COPY --from=download /tmp/kubectl /usr/local/bin/
+
+RUN apt-get update && \
+    apt-get install -y \
+        git \
+        curl \
+    && rm -rf /var/lib/apt/lists/*
+


### PR DESCRIPTION
This is the _third_ time I'm trying to make Prow merge my PR (previously: #35 and #34).

> This PR is a follow-up to the discussion in Slack regarding the CI job base image.
>
> I've tried my hands at creating a simple version of a build image that ships with Go 1.19.9 and kubectl 1.26.3 and is built via GitHub Actions, since kcp images are currently published as GitHub Packages. I'm very very new to GitHub Actions, so I hope what I built here makes sense. It might not be the way to go for us, so this is open to discussions.