### PR TITLE
🐛  correct format of build args passed to GitHub Actions

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -48,4 +48,6 @@ jobs:
           platforms: linux/amd64
           cache-from: type=gha,scope=${{ github.ref_name }}-buildx
           cache-to: type=gha,scope=${{ github.ref_name }}-buildx,mode=max
-          build-args: GO_VERSION=1.19.9,K8S_VERSION=1.26.3
+          build-args: |
+            GO_VERSION=1.19.9
+            K8S_VERSION=1.26.3


### PR DESCRIPTION
`build-args` needs to be passed in a different format. Also see [Actions documentation](https://github.com/docker/build-push-action#customizing) for the proper way to pass a list.