### PR TITLE
change owner file names for kcp-dev/controller-runtime

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -110,3 +110,9 @@ external_plugins:
       events:
         - issue_comment
         - pull_request
+
+owners:
+  filenames:
+    kcp-dev/controller-runtime:
+      owners: DOWNSTREAM_OWNERS
+      owners_aliases: DOWNSTREAM_OWNERS_ALIASES


### PR DESCRIPTION
This makes it so Prow ignores the upstream files (OWNERS) and instead uses our files, otherwise we could not approve our own PRs.

This mirrors https://github.com/openshift/release/blob/master/core-services/prow/02_config/_plugins.yaml#L2688