### PR TITLE
add preset-ghcr-credentials Prow preset

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -315,3 +315,20 @@ presets:
       - name: prow-kubeconfig
         secret:
           secretName: kubeconfig
+
+  ################################################################
+  # (prow-cluster only) username and password for GHCR
+
+  - labels:
+      preset-ghcr-credentials: "true"
+    env:
+      - name: KCP_GHCR_USERNAME
+        valueFrom:
+          secretKeyRef:
+            name: ghcr-credentials
+            key: username
+      - name: KCP_GHCR_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: ghcr-credentials
+            key: password


### PR DESCRIPTION
xref https://kubernetes.slack.com/archives/C021U8WSAFK/p1686089777445089

This provides a new preset for prowjobs to gain access to the GHCR. Prowjob will need to run in the somewhat protected prow cluster instead of the regular build cluster, as a little extra security. The credentials in this secret can _only_ manage packages and nothing else.