### PR TITLE
Add post-kcp-publish-image job

### DIFF
--- a/prow/jobs/kcp/kcp-postsubmits.yaml
+++ b/prow/jobs/kcp/kcp-postsubmits.yaml
@@ -1,0 +1,24 @@
+postsubmits:
+  kcp-dev/kcp:
+    - name: post-kcp-publish-image
+      decorate: true
+      clone_uri: "https://github.com/kcp-dev/kcp"
+      cluster: prow # GHCR credentials are only available here
+      labels:
+        preset-ghcr-credentials: "true"
+      branches:
+        - ^main$
+        - ^release-.*
+        - ^v\d+\..*
+      spec:
+        containers:
+          - image: quay.io/containers/buildah:v1.30.0
+            command:
+              - hack/build-image.sh
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: 2
+                memory: 3Gi


### PR DESCRIPTION
This is the sister PR to https://github.com/kcp-dev/kcp/pull/2976, adding the necessary postsubmit.

Images were previously built for main/release branches and for tags ( https://github.com/kcp-dev/kcp/blob/main/.github/workflows/kcp-image.yaml#L8-L12 ), so I kept this behaviour.