### PR TITLE
reduce build cluster size to save money

### DIFF
--- a/clusters/build/manifests/machinedeployment-worker.yaml
+++ b/clusters/build/manifests/machinedeployment-worker.yaml
@@ -4,8 +4,8 @@ metadata:
   name: worker
   namespace: kube-system
   annotations:
-    cluster.k8s.io/cluster-api-autoscaler-node-group-min-size: "3"
-    cluster.k8s.io/cluster-api-autoscaler-node-group-max-size: "30"
+    cluster.k8s.io/cluster-api-autoscaler-node-group-min-size: "1"
+    cluster.k8s.io/cluster-api-autoscaler-node-group-max-size: "10"
 spec:
   # do not specify replica count, as its going to be dynamically altered
   # for our custom scale up/down solution


### PR DESCRIPTION
There is no need to keep 3 large machines running at all times, given the current CI volume. Likewise there should be no scenario at which we need to burst to 30 machines at the same time.

Hence this PR reduces the scaling parameters in order to save money.