### PR TITLE
🌱  Include kind and docker in build image

### DIFF
--- a/images/build/Dockerfile
+++ b/images/build/Dockerfile
@@ -5,16 +5,30 @@ FROM docker.io/library/golang:${GO_VERSION} as download
 # this needs to be separate from the GO_VERSION arg above because otherwise
 # it is not in scope for usage in the RUN instructions below.
 ARG K8S_VERSION
+ARG KIND_VERSION
 
 WORKDIR /tmp
 
-RUN curl --fail -Lo kubectl https://dl.k8s.io/release/v${K8S_VERSION}/bin/linux/amd64/kubectl && \
+RUN curl --fail -Lo kubectl https://dl.k8s.io/release/v${K8S_VERSION}/bin/linux/$(dpkg --print-architecture)/kubectl && \
     chmod +x kubectl && \
     ./kubectl version --short --client
 
+RUN curl --fail -Lo kind https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-linux-$(dpkg --print-architecture) && \
+    chmod +x kind && \
+    ./kind version
+
 FROM docker.io/library/golang:${GO_VERSION}
 
+# this is used by docker as data root
+VOLUME /docker-graph
+
 COPY --from=download /tmp/kubectl /usr/local/bin/
+COPY --from=download /tmp/kind /usr/local/bin/
+
+COPY start-docker.sh /usr/local/bin/
+# this pre-loads the kindest/node image so it can be loaded via docker
+# when starting a container based on this image
+COPY kindest.tar /kindest.tar
 
 RUN apt-get update && \
     apt-get install -y \
@@ -22,4 +36,14 @@ RUN apt-get update && \
         curl \
         jq \
     && rm -rf /var/lib/apt/lists/*
+
+# install Docker (and socat for tunneling the docker registry later)
+RUN curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg | gpg --dearmor > /usr/share/keyrings/docker.com.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker.com.gpg] https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | tee /etc/apt/sources.list.d/docker.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends docker-ce=5:23.0.* socat && \
+    sed -i 's/cgroupfs_mount$/#cgroupfs_mount\n/' /etc/init.d/docker && \
+    mkdir -p /etc/docker && \
+    echo '{"data-root":"/docker-graph"}' | jq '.' > /etc/docker/daemon.json && \
+    rm -rf /var/lib/apt/lists/*
 

--- a/images/build/README.md
+++ b/images/build/README.md
@@ -1,0 +1,17 @@
+# kcp-dev/infra/build
+
+This directory contains files to build `ghcr.io/kcp-dev/infra/build`, the base image used for kcp's Prow jobs. It includes the following tools:
+
+- `docker` (and `/usr/local/bin/start-docker.sh` to start it)
+-  `kind` (and pre-loaded `/kindest.tar` that can be loaded into docker to have `kindest/node` available)
+- `go`
+- `git`, `jq` and `curl`
+
+## Usage
+
+- Mount an emptyDir volume to `/docker-graph`, which is used by docker as data root. This is not strictly required but stongly suggested.
+- Configure the command to be `["/bin/bash", "-c", "/usr/local/bin/start-docker.sh && $YOUR_ACTUAL_COMMAND"]`, this is required because Prow overrides the image entrypoint.
+
+## Updates
+
+Main component versions (Go, kind, etc) can be updated in [env](./env). Make sure to bump `BUILD_IMAGE_TAG` accordingly (the usual pattern is Go version plus a suffix that is incremented upon other version updates or addition of some tools).

--- a/images/build/env
+++ b/images/build/env
@@ -1,3 +1,10 @@
+# the tag used for the final image. Update the suffix when you want
+# a new version of the image to be built.
 BUILD_IMAGE_TAG=1.19.9-3
+# the Go version used for the images.
 GO_IMAGE_VERSION=1.19.9
+# the Kubernetes version that is used to determine which kubectl to
+# install into the image.
 K8S_VERSION=1.26.3
+# the kind version installed into this image.
+KIND_VERSION=0.18.0

--- a/images/build/env
+++ b/images/build/env
@@ -3,8 +3,8 @@
 BUILD_IMAGE_TAG=1.19.9-3
 # the Go version used for the images.
 GO_IMAGE_VERSION=1.19.9
-# the Kubernetes version that is used to determine which kubectl to
-# install into the image.
+# the Kubernetes version that is used to determine which kubectl 
+# to install and which kind node image to pre-load into the image.
 K8S_VERSION=1.26.3
 # the kind version installed into this image.
 KIND_VERSION=0.18.0

--- a/images/build/hack/build-image.sh
+++ b/images/build/hack/build-image.sh
@@ -39,6 +39,11 @@ cd ./images/build
 # read configuration file for build image
 source ./env
 
+# download kind image
+echo "Downloading kindest image to embed into image ..."
+buildah pull docker.io/kindest/node:v${K8S_VERSION}
+buildah push --format docker docker.io/kindest/node:v${K8S_VERSION} docker-archive:kindest.tar:kindest/node:v${K8S_VERSION}
+
 image="$repository:${BUILD_IMAGE_TAG}"
 echo "Building container image $image ..."
 
@@ -46,14 +51,15 @@ echo "Building container image $image ..."
 for arch in $architectures; do
   fullTag="$image-$arch"
 
-  echo "Building $version-$arch ..."
+  echo "Building $image-$arch ..."
   buildah build-using-dockerfile \
     --file Dockerfile \
     --tag "$fullTag" \
     --arch "$arch" \
     --override-arch "$arch" \
     --build-arg "GO_VERSION=${GO_IMAGE_VERSION}" \
-    --build-arg "K8S_VERSION=${K8S_VERSION}"
+    --build-arg "K8S_VERSION=${K8S_VERSION}" \
+    --build-arg "KIND_VERSION=${KIND_VERSION}" \
     --format=docker \
     .
 done

--- a/images/build/start-docker.sh
+++ b/images/build/start-docker.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+## This script should be called by all containers that
+## want to use docker-in-docker. This ensures a consistent
+## setup instead of homegrown custom hacks in each
+## repository.
+## It is safe to call this multiple times, only the first
+## invocation will start the daemon.
+
+set -euo pipefail
+
+retry() {
+  # Works only with bash but doesn't fail on other shells
+  set +e
+  actual_retry $@
+  rc=$?
+  set -e
+  return $rc
+}
+
+# We use an extra wrapping to write junit and have a timer
+actual_retry() {
+  retries=$1
+  shift
+
+  count=0
+  delay=1
+  until "$@"; do
+    rc=$?
+    count=$((count + 1))
+    if [ $count -lt "$retries" ]; then
+      echo "Retry $count/$retries exited $rc, retrying in $delay seconds..." > /dev/stderr
+      sleep $delay
+    else
+      echo "Retry $count/$retries exited $rc, no more retries left." > /dev/stderr
+      return $rc
+    fi
+    delay=$((delay + 1))
+  done
+  return 0
+}
+
+echodate() {
+  # do not use -Is to keep this compatible with macOS
+  echo "[$(date +%Y-%m-%dT%H:%M:%S%:z)]" "$@"
+}
+
+# does Docker already run?
+if docker stats --no-stream > /dev/null 2>&1; then
+  exit 0
+fi
+
+echodate "Starting Docker"
+
+# This is needed so Docker-In-Docker still works when the peer doesn't allow ICMP packages and hence path mtu discovery cant work
+# Most notably, pmtud doesn't work with the hoster of the Alpine package mirror, fastly, causing dind builds of alpine to hang
+# forever. Upstream issue: See https://github.com/gliderlabs/docker-alpine/issues/307#issuecomment-427246497
+echodate "Configuring iptables"
+iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
+
+# Configure a registry mirror. This will help only the `docker build` commands during
+# regular Prow job, but will not affect any kind clusters that are started from within
+# Prow jobs.
+registryMirror="${DOCKER_REGISTRY_MIRROR:-}"
+if [ -n "$registryMirror" ]; then
+  echodate "Configuring registry mirror"
+  jq --arg mirror "$registryMirror" '."registry-mirrors" = [$mirror]' /etc/docker/daemon.json > /etc/docker/daemon.new.json
+  mv /etc/docker/daemon.new.json /etc/docker/daemon.json
+fi
+
+mtu=${DOCKER_MTU:-0}
+if [[ $mtu -gt 0 ]]; then
+  echodate "Configuring MTU"
+  jq --argjson mtu $mtu '.mtu = $mtu' /etc/docker/daemon.json > /etc/docker/daemon.new.json
+  mv /etc/docker/daemon.new.json /etc/docker/daemon.json
+fi
+
+# start Docker daemon
+service docker start
+
+# wait for Docker to start
+retry 5 docker stats --no-stream
+echodate "Docker became ready"


### PR DESCRIPTION
This PR includes `kind` and `docker` in the build image and provides a script to start up docker. The README.md included has all the details on how the image should be used, so I don't want to duplicate that information.

We also pre-load a kindest/node image into the image that can be loaded during a Prow job so it doesn't have to be pulled every time.