### PR TITLE
migrate edge-mc to kubestellar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # infra
 
-This repository contains tools and configuration files for the testing and automation needs of the `kcp-dev` organization.
+This repository contains tools and configuration files for the testing and automation needs of the `kcp-dev` an `kubestellar` organizations.
 
 ## Prow (CI)
 

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -28,7 +28,7 @@ plank:
     'kcp-dev/kcp-dev.github.io': '[Full PR test history](https://public-prow.kcp.k8c.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}})'
     'kcp-dev/kcp.io': '[Full PR test history](https://public-prow.kcp.k8c.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}})'
     'kcp-dev/logicalcluster': '[Full PR test history](https://public-prow.kcp.k8c.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}})'
-    'kcp-dev/edge-mc': '[Full PR test history](https://public-prow.kcp.k8c.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}})'
+    'kubestellar/kubestellar': '[Full PR test history](https://public-prow.kcp.k8c.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}})'
 
   job_url_prefix_config:
     '*': https://prow.kcp.k8c.io/view/
@@ -47,7 +47,7 @@ plank:
     'kcp-dev/kcp-dev.github.io': 'https://public-prow.kcp.k8c.io/view/'
     'kcp-dev/kcp.io': 'https://public-prow.kcp.k8c.io/view/'
     'kcp-dev/logicalcluster': 'https://public-prow.kcp.k8c.io/view/'
-    'kcp-dev/edge-mc': 'https://public-prow.kcp.k8c.io/view/'
+    'kubestellar/kubestellar': 'https://public-prow.kcp.k8c.io/view/'
 
   default_decoration_config_entries:
     # default config
@@ -143,7 +143,7 @@ plank:
         s3_credentials_secret: "s3-credentials-public"
         gcs_configuration:
           bucket: "s3://prow-public-data"
-    - repo: "kcp-dev/edge-mc"
+    - repo: "kubestellar/kubestellar"
       config:
         s3_credentials_secret: "s3-credentials-public"
         gcs_configuration:
@@ -222,6 +222,7 @@ tide:
 
   merge_method:
     kcp-dev: merge
+    kubestellar: merge
 
   queries:
     # no release notes
@@ -239,7 +240,7 @@ tide:
         - kcp-dev/infra
         - kcp-dev/kcp-dev.github.io
         - kcp-dev/kcp.io
-        - kcp-dev/edge-mc
+        - kubestellar/kubestellar
       labels:
         - lgtm
         - approved
@@ -278,6 +279,18 @@ branch-protection:
         users: []
         teams:
           - kcp-dev/kcp-admins
+      include:
+        - "^main$"
+
+    kubestellar:
+      protect: true
+      required_status_checks:
+        contexts:
+        - dco
+      restrictions:
+        users: []
+        teams:
+          - kubestellar/kubestellar-admins
       include:
         - "^main$"
 

--- a/prow/jobs/kubestellar/kubestellar/kubestellar-presubmits.yaml
+++ b/prow/jobs/kubestellar/kubestellar/kubestellar-presubmits.yaml
@@ -1,9 +1,9 @@
 presubmits:
-  kcp-dev/edge-mc:
-    - name: pull-edge-mc-validate-prow-yaml
+  kubestellar/kubestellar:
+    - name: pull-kubestellar-kubestellar-validate-prow-yaml
       always_run: true
       decorate: true
-      clone_uri: "ssh://git@github.com/kcp-dev/edge-mc.git"
+      clone_uri: "ssh://git@github.com/kubestellar/kubestellar.git"
       extra_refs:
         - org: kcp-dev
           repo: infra

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -6,17 +6,20 @@
 triggers:
   - repos:
       - kcp-dev
+      - kubestellar
     only_org_members: true
 
 approve:
   - repos:
       - kcp-dev
+      - kubestellar
     ignore_review_state: true
     require_self_approval: true
 
 lgtm:
   - repos:
       - kcp-dev
+      - kubestellar
     # adds lgtm if GitHub review state is "Approve"
     # and removes lgtm if review state is "Request Changes"
     review_acts_as_lgtm: true
@@ -45,10 +48,6 @@ cherry_pick_unapproved:
     Adding the `do-not-merge/cherry-pick-not-approved` label.
 
     To merge this cherry pick, it must first be approved (`/lgtm` + `/approve`) by the relevant OWNERS.
-
-    **AFTER** it has been approved by code owners, please leave the following comment on a line **by itself, with no leading whitespace**: `cc @kcp-dev/sig-release-managers`.
-
-    (This command will request a cherry pick review from [Release Managers](https://github.com/orgs/kcp-dev/teams/sig-release-managers) and should work for all GitHub users, whether they are members of the kcp-dev GitHub organization or not.)
 
 dco:
   '*':
@@ -101,8 +100,36 @@ plugins:
     plugins:
       - config-updater # updates prow configuration
 
+  kubestellar:
+    plugins:
+      - approve
+      - assign
+      - branchcleaner
+      - dco
+      - hold
+      - label           # adds or removes labels of the type area/*, kind/*, etc
+      - lgtm
+      - lifecycle       # allows to close or open issues for non-members, mark issues and PRs as stale, etc
+      - milestoneapplier
+      - override
+      - owners-label    # automatically adds labels to PRs based on the files they touch; labels are mentioned in the OWNERS file
+      - retitle         # /retitle allows to edit the title of a PR (e.g. to remove WIP, when people are on vacation)
+      - size
+      - skip            # /skip cleans up commit statuses of non-blocking presubmits on PRs
+      - trigger
+      - verify-owners   # verifies format of OWNERS file
+      - wip
+
 external_plugins:
   kcp-dev:
+    - name: needs-rebase
+      events:
+        - pull_request
+    - name: cherrypicker
+      events:
+        - issue_comment
+        - pull_request
+  kubestellar:
     - name: needs-rebase
       events:
         - pull_request


### PR DESCRIPTION
This PR converts the Prow config for `kcp-dev/edge-mc` to `kubestellar/kubestellar`.