### PR TITLE
prow: enable transfer-issue plugin for kcp-dev org

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -84,6 +84,7 @@ plugins:
       - retitle         # /retitle allows to edit the title of a PR (e.g. to remove WIP, when people are on vacation)
       - size
       - skip            # /skip cleans up commit statuses of non-blocking presubmits on PRs
+      - transfer-issue  # /transfer[-issue] <repo name in same org> transfers GitHub issue to dest. repo
       - trigger
       - verify-owners   # verifies format of OWNERS file
       - wip


### PR DESCRIPTION
Enabling the `transfer-issue` plugin to aid with when we have a new repo for something like tmc and we need to migrate away the issues in kcp-dev/kcp to this repo.

Note: this plugin works only for transferring issues between repos of the same org.

/assign @xrstf 