### PR TITLE
Update build image to Go 1.20, Kubernetes 1.28, kind 0.20

### DIFF
--- a/images/build/Dockerfile
+++ b/images/build/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /tmp
 
 RUN curl --fail -Lo kubectl https://dl.k8s.io/release/v${K8S_VERSION}/bin/linux/$(dpkg --print-architecture)/kubectl && \
     chmod +x kubectl && \
-    ./kubectl version --short --client
+    ./kubectl version --client
 
 RUN curl --fail -Lo kind https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-linux-$(dpkg --print-architecture) && \
     chmod +x kind && \

--- a/images/build/env
+++ b/images/build/env
@@ -5,6 +5,6 @@ BUILD_IMAGE_TAG=1.20.7-1
 GO_IMAGE_VERSION=1.20.7
 # the Kubernetes version that is used to determine which kubectl 
 # to install and which kind node image to pre-load into the image.
-K8S_VERSION=1.28.1
+K8S_VERSION=1.28.0
 # the kind version installed into this image.
 KIND_VERSION=0.20.0

--- a/images/build/env
+++ b/images/build/env
@@ -1,10 +1,10 @@
 # the tag used for the final image. Update the suffix when you want
 # a new version of the image to be built.
-BUILD_IMAGE_TAG=1.19.9-3
+BUILD_IMAGE_TAG=1.20.7-1
 # the Go version used for the images.
-GO_IMAGE_VERSION=1.19.9
+GO_IMAGE_VERSION=1.20.7
 # the Kubernetes version that is used to determine which kubectl 
 # to install and which kind node image to pre-load into the image.
-K8S_VERSION=1.26.3
+K8S_VERSION=1.28.1
 # the kind version installed into this image.
-KIND_VERSION=0.18.0
+KIND_VERSION=0.20.0


### PR DESCRIPTION
This updates the build image to Go 1.20.7, Kubernetes 1.28.0 and kind 0.20.0. It's required for the Kubernetes 1.28 rebase (#3003).