### PR TITLE
add Helm to build image

### DIFF
--- a/images/build/Dockerfile
+++ b/images/build/Dockerfile
@@ -6,8 +6,13 @@ FROM docker.io/library/golang:${GO_VERSION} as download
 # it is not in scope for usage in the RUN instructions below.
 ARG K8S_VERSION
 ARG KIND_VERSION
+ARG HELM_VERSION
 
 WORKDIR /tmp
+
+RUN curl --fail -L https://get.helm.sh/helm-v${HELM_VERSION}-linux-$(dpkg --print-architecture).tar.gz | tar -xzO linux-$(dpkg --print-architecture)/helm > helm && \
+    chmod +x helm && \
+    ./helm version --short
 
 RUN curl --fail -Lo kubectl https://dl.k8s.io/release/v${K8S_VERSION}/bin/linux/$(dpkg --print-architecture)/kubectl && \
     chmod +x kubectl && \
@@ -24,6 +29,7 @@ VOLUME /docker-graph
 
 COPY --from=download /tmp/kubectl /usr/local/bin/
 COPY --from=download /tmp/kind /usr/local/bin/
+COPY --from=download /tmp/helm /usr/local/bin/
 
 COPY start-docker.sh /usr/local/bin/
 # this pre-loads the kindest/node image so it can be loaded via docker

--- a/images/build/env
+++ b/images/build/env
@@ -1,10 +1,12 @@
 # the tag used for the final image. Update the suffix when you want
 # a new version of the image to be built.
-BUILD_IMAGE_TAG=1.20.7-1
+BUILD_IMAGE_TAG=1.20.8-1
 # the Go version used for the images.
-GO_IMAGE_VERSION=1.20.7
-# the Kubernetes version that is used to determine which kubectl 
+GO_IMAGE_VERSION=1.20.8
+# the Kubernetes version that is used to determine which kubectl
 # to install and which kind node image to pre-load into the image.
 K8S_VERSION=1.28.0
 # the kind version installed into this image.
 KIND_VERSION=0.20.0
+# the Helm version installed into this image.
+HELM_VERSION=3.12.3

--- a/images/build/hack/build-image.sh
+++ b/images/build/hack/build-image.sh
@@ -60,6 +60,7 @@ for arch in $architectures; do
     --build-arg "GO_VERSION=${GO_IMAGE_VERSION}" \
     --build-arg "K8S_VERSION=${K8S_VERSION}" \
     --build-arg "KIND_VERSION=${KIND_VERSION}" \
+    --build-arg "HELM_VERSION=${HELM_VERSION}" \
     --format=docker \
     .
 done


### PR DESCRIPTION
Helm is used to run presubmit tests in the helm-charts repo.