### PR TITLE
add kubeconform to build image

### DIFF
--- a/images/build/Dockerfile
+++ b/images/build/Dockerfile
@@ -7,6 +7,7 @@ FROM docker.io/library/golang:${GO_VERSION} as download
 ARG K8S_VERSION
 ARG KIND_VERSION
 ARG HELM_VERSION
+ARG KUBECONFORM_VERSION
 
 WORKDIR /tmp
 
@@ -21,6 +22,10 @@ RUN curl --fail -Lo kubectl https://dl.k8s.io/release/v${K8S_VERSION}/bin/linux/
 RUN curl --fail -Lo kind https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-linux-$(dpkg --print-architecture) && \
     chmod +x kind && \
     ./kind version
+
+RUN curl --fail -L https://github.com/yannh/kubeconform/releases/download/v${KUBECONFORM_VERSION}/kubeconform-linux-$(dpkg --print-architecture).tar.gz | tar -xzO kubeconform-linux-$(dpkg --print-architecture)/kubeconform > kubeconform && \
+    chmod +x kubeconform && \
+    ./kubeconform -v
 
 FROM docker.io/library/golang:${GO_VERSION}
 

--- a/images/build/Dockerfile
+++ b/images/build/Dockerfile
@@ -23,7 +23,7 @@ RUN curl --fail -Lo kind https://github.com/kubernetes-sigs/kind/releases/downlo
     chmod +x kind && \
     ./kind version
 
-RUN curl --fail -L https://github.com/yannh/kubeconform/releases/download/v${KUBECONFORM_VERSION}/kubeconform-linux-$(dpkg --print-architecture).tar.gz | tar -xzO kubeconform-linux-$(dpkg --print-architecture)/kubeconform > kubeconform && \
+RUN curl --fail -L https://github.com/yannh/kubeconform/releases/download/v${KUBECONFORM_VERSION}/kubeconform-linux-$(dpkg --print-architecture).tar.gz | tar -xzO kubeconform > kubeconform && \
     chmod +x kubeconform && \
     ./kubeconform -v
 

--- a/images/build/README.md
+++ b/images/build/README.md
@@ -6,6 +6,7 @@ This directory contains files to build `ghcr.io/kcp-dev/infra/build`, the base i
 -  `kind` (and pre-loaded `/kindest.tar` that can be loaded into docker to have `kindest/node` available)
 - `go`
 - `git`, `jq` and `curl`
+- `kubeconform`
 
 ## Usage
 

--- a/images/build/env
+++ b/images/build/env
@@ -1,6 +1,6 @@
 # the tag used for the final image. Update the suffix when you want
 # a new version of the image to be built.
-BUILD_IMAGE_TAG=1.20.9-1
+BUILD_IMAGE_TAG=1.20.9-2
 # the Go version used for the images.
 GO_IMAGE_VERSION=1.20.9
 # the Kubernetes version that is used to determine which kubectl
@@ -10,3 +10,5 @@ K8S_VERSION=1.28.0
 KIND_VERSION=0.20.0
 # the Helm version installed into this image.
 HELM_VERSION=3.12.3
+# the kubeconform version installed into this image.
+KUBECONFORM_VERSION=0.6.4

--- a/images/build/hack/build-image.sh
+++ b/images/build/hack/build-image.sh
@@ -61,6 +61,7 @@ for arch in $architectures; do
     --build-arg "K8S_VERSION=${K8S_VERSION}" \
     --build-arg "KIND_VERSION=${KIND_VERSION}" \
     --build-arg "HELM_VERSION=${HELM_VERSION}" \
+    --build-arg "KUBECONFORM_VERSION=${KUBECONFORM_VERSION}" \
     --format=docker \
     .
 done


### PR DESCRIPTION
I would like to add [kubeconform](https://github.com/yannh/kubeconform) to our build image. The reason being that I want this tool to validate our Helm chart after templating it, to make sure that the manifests generated by the chart are not only correct YAML but also semantically correct Kubernetes manifests. Helm currently doesn't check for this as far as I know.