### PR TITLE
🐛  correctly copy kubeconform binary into final build image stage

### DIFF
--- a/images/build/Dockerfile
+++ b/images/build/Dockerfile
@@ -35,6 +35,7 @@ VOLUME /docker-graph
 COPY --from=download /tmp/kubectl /usr/local/bin/
 COPY --from=download /tmp/kind /usr/local/bin/
 COPY --from=download /tmp/helm /usr/local/bin/
+COPY --from=download /tmp/kubeconform /usr/local/bin/
 
 COPY start-docker.sh /usr/local/bin/
 # this pre-loads the kindest/node image so it can be loaded via docker

--- a/images/build/env
+++ b/images/build/env
@@ -1,6 +1,6 @@
 # the tag used for the final image. Update the suffix when you want
 # a new version of the image to be built.
-BUILD_IMAGE_TAG=1.20.9-2
+BUILD_IMAGE_TAG=1.20.9-3
 # the Go version used for the images.
 GO_IMAGE_VERSION=1.20.9
 # the Kubernetes version that is used to determine which kubectl


### PR DESCRIPTION
Follow-up to #62. It usually helps to actually copy the binary to where you need it.