### PR TITLE
Bump build image to `1.20.13-1`, updating Go to 1.20.13

### DIFF
--- a/images/build/env
+++ b/images/build/env
@@ -1,8 +1,8 @@
 # the tag used for the final image. Update the suffix when you want
 # a new version of the image to be built.
-BUILD_IMAGE_TAG=1.20.9-3
+BUILD_IMAGE_TAG=1.20.13-1
 # the Go version used for the images.
-GO_IMAGE_VERSION=1.20.9
+GO_IMAGE_VERSION=1.20.13
 # the Kubernetes version that is used to determine which kubectl
 # to install and which kind node image to pre-load into the image.
 K8S_VERSION=1.28.0


### PR DESCRIPTION
Some housekeeping before the kcp release, updating to the latest Go 1.20.

/cc @xrstf