### PR TITLE
Bump to Go 1.21.8

### DIFF
--- a/images/build/env
+++ b/images/build/env
@@ -1,8 +1,8 @@
 # the tag used for the final image. Update the suffix when you want
 # a new version of the image to be built.
-BUILD_IMAGE_TAG=1.20.13-1
+BUILD_IMAGE_TAG=1.21.8-1
 # the Go version used for the images.
-GO_IMAGE_VERSION=1.20.13
+GO_IMAGE_VERSION=1.21.8
 # the Kubernetes version that is used to determine which kubectl
 # to install and which kind node image to pre-load into the image.
 K8S_VERSION=1.28.0


### PR DESCRIPTION
Needed for run controller-runtime 0.17.2 tests in https://github.com/kcp-dev/controller-runtime/pull/48.