### PR TITLE
define periodics to implement issue lifecycle

### DIFF
--- a/hack/ci/github-decay-issues.sh
+++ b/hack/ci/github-decay-issues.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+
+set -e
+
+# This script runs in the gcr.io/k8s-prow/commenter image
+# and takes care of marking Github issues without activity
+# progressively as stale, rotten and eventually closes them.
+
+if [ -z "${GITHUB_TOKEN_FILE:-}" ]; then
+  echo "No GITHUB_TOKEN_FILE variable set."
+  exit 1
+fi
+
+# this will be added to every search query
+baseQuery='repo:kcp-dev/kcp
+repo:kcp-dev/helm-charts
+repo:kcp-dev/infra
+repo:kcp-dev/controller-runtime
+repo:kcp-dev/controller-runtime-example
+repo:kcp-dev/logicalcluster
+repo:kcp-dev/kcp.io
+-label:kind/documentation
+-label:kind/feature
+-label:kind/cleanup
+-label:epic'
+
+case "$KIND" in
+  stale)
+    updated=2160h
+    query='-label:lifecycle/frozen -label:lifecycle/stale -label:lifecycle/rotten'
+    comment='Issues go stale after 90d of inactivity.
+After a furter 30 days, they will turn rotten.
+Mark the issue as fresh with `/remove-lifecycle stale`.
+
+If this issue is safe to close now please do so with `/close`.
+
+/lifecycle stale'
+    ;;
+
+  rotten)
+    updated=720h
+    query='-label:lifecycle/frozen label:lifecycle/stale -label:lifecycle/rotten'
+  comment='Stale issues rot after 30d of inactivity.
+Mark the issue as fresh with `/remove-lifecycle rotten`.
+Rotten issues close after an additional 30d of inactivity.
+
+If this issue is safe to close now please do so with `/close`.
+
+/lifecycle rotten'
+    ;;
+
+  close)
+    updated=720h
+    query='-label:lifecycle/frozen label:lifecycle/rotten'
+  comment='Rotten issues close after 30d of inactivity.
+Reopen the issue with `/reopen`.
+Mark the issue as fresh with `/remove-lifecycle rotten`.
+
+/close'
+    ;;
+
+*)
+    echo "Invalid \$KIND given: $KIND"
+    exit 1
+    ;;
+esac
+
+# safety first, set $CONFIRM to any value to actually perform changes
+confirmFlag=''
+if [ -n "${CONFIRM:-}" ]; then
+  confirmFlag='-confirm'
+fi
+
+commenter $confirmFlag \
+  -query="$baseQuery $query" \
+  -updated=$updated \
+  -token="$GITHUB_TOKEN_FILE" \
+  -comment="$comment" \
+  -template \
+  -ceiling=10

--- a/prow/jobs/kcp-dev/infra/infra-periodics-lifecycle.yaml
+++ b/prow/jobs/kcp-dev/infra/infra-periodics-lifecycle.yaml
@@ -1,0 +1,108 @@
+periodics:
+  - name: periodic-infra-github-stale-issues
+    interval: 12h
+    cluster: prow
+    annotations:
+      description: Adds lifecycle/stale to issues after 90d of inactivity
+    hidden: true
+    decorate: true
+    extra_refs:
+      - org: kcp-dev
+        repo: infra
+        base_ref: main
+        clone_uri: "git@github.com:kcp-dev/infra.git"
+    spec:
+      containers:
+        - image: gcr.io/k8s-prow/commenter:v20230523-2834e18241
+          command:
+            - ./hack/ci/github-decay-issues.sh
+          env:
+            - name: KIND
+              value: stale
+            - name: CONFIRM
+              value: 'yes'
+            - name: GITHUB_TOKEN_FILE
+              value: /etc/token/token
+          volumeMounts:
+            - name: token
+              mountPath: /etc/token
+          resources:
+            requests:
+              cpu: 500m
+              memory: 128Mi
+      volumes:
+        - name: token
+          secret:
+            secretName: github-token
+
+  - name: periodic-infra-github-rotten-issues
+    interval: 12h
+    cluster: prow
+    annotations:
+      description: Adds lifecycle/rotten to stale issues after 30d of inactivity
+    hidden: true
+    decorate: true
+    extra_refs:
+      - org: kcp-dev
+        repo: infra
+        base_ref: main
+        clone_uri: "git@github.com:kcp-dev/infra.git"
+    spec:
+      containers:
+        - image: gcr.io/k8s-prow/commenter:v20230523-2834e18241
+          command:
+            - ./hack/ci/github-decay-issues.sh
+          env:
+            - name: KIND
+              value: rotten
+            - name: CONFIRM
+              value: 'yes'
+            - name: GITHUB_TOKEN_FILE
+              value: /etc/token/token
+          volumeMounts:
+            - name: token
+              mountPath: /etc/token
+          resources:
+            requests:
+              cpu: 500m
+              memory: 128Mi
+      volumes:
+        - name: token
+          secret:
+            secretName: github-token
+
+  - name: periodic-infra-github-close-issues
+    interval: 12h
+    cluster: prow
+    annotations:
+      description: Closes rotten issues after 30d of inactivity
+    hidden: true
+    decorate: true
+    extra_refs:
+      - org: kcp-dev
+        repo: infra
+        base_ref: main
+        clone_uri: "git@github.com:kcp-dev/infra.git"
+    spec:
+      containers:
+        - image: gcr.io/k8s-prow/commenter:v20230523-2834e18241
+          command:
+            - ./hack/ci/github-decay-issues.sh
+          env:
+            - name: KIND
+              value: close
+            - name: CONFIRM
+              value: 'yes'
+            - name: GITHUB_TOKEN_FILE
+              value: /etc/token/token
+          volumeMounts:
+            - name: token
+              mountPath: /etc/token
+          resources:
+            requests:
+              cpu: 500m
+              memory: 128Mi
+      volumes:
+        - name: token
+          secret:
+            secretName: github-token


### PR DESCRIPTION
These new jobs will let old tickets progressively age and then close them. The plugin itself, for the `/lifecycle` commands, has already been enabled since the beginning.