### PR TITLE
Register gcp postsubmits to correct repository

### DIFF
--- a/prow/jobs/kcp-dev/generic-controlplane/gcp-postsubmits.yaml
+++ b/prow/jobs/kcp-dev/generic-controlplane/gcp-postsubmits.yaml
@@ -1,5 +1,5 @@
 postsubmits:
-  kcp-dev/kcp:
+  kcp-dev/generic-controlplane:
     - name: post-gcp-publish-image
       decorate: true
       clone_uri: "https://github.com/kcp-dev/generic-controlplane"


### PR DESCRIPTION
Minor issue in #70, the new postsubmit got added to the wrong repository. It got triggered on a kcp-dev/kcp PR merge and fails: https://public-prow.kcp.k8c.io/view/s3/prow-public-data/logs/post-gcp-publish-image/1791478801046179840.

/cc @xrstf @mjudeikis 