### PR TITLE
Update to Go 1.22.5, Kubernetes 1.30 and build arm64 images

### DIFF
--- a/images/build/env
+++ b/images/build/env
@@ -1,14 +1,14 @@
 # the tag used for the final image. Update the suffix when you want
 # a new version of the image to be built.
-BUILD_IMAGE_TAG=1.22.2-1
+BUILD_IMAGE_TAG=1.22.5-1
 # the Go version used for the images.
-GO_IMAGE_VERSION=1.22.2
+GO_IMAGE_VERSION=1.22.5
 # the Kubernetes version that is used to determine which kubectl
 # to install and which kind node image to pre-load into the image.
-K8S_VERSION=1.28.0
+K8S_VERSION=1.30.0
 # the kind version installed into this image.
 KIND_VERSION=0.20.0
 # the Helm version installed into this image.
-HELM_VERSION=3.12.3
+HELM_VERSION=3.15.3
 # the kubeconform version installed into this image.
-KUBECONFORM_VERSION=0.6.4
+KUBECONFORM_VERSION=0.6.6

--- a/images/build/hack/build-image.sh
+++ b/images/build/hack/build-image.sh
@@ -32,7 +32,7 @@ EOF
 fi
 
 repository=ghcr.io/kcp-dev/infra/build
-architectures="amd64"
+architectures="amd64 arm64"
 
 cd ./images/build
 


### PR DESCRIPTION
Now that https://github.com/kcp-dev/kcp/pull/3140 has been merged, this refreshes the build image to:

1. Use the latest Go 1.22.5.
2. Use Kubernetes 1.30.
3. Update Helm and kubeconform to their latest versions.
4. Build an `arm64` variant of the image so we can run jobs on OCI (#68).