### PR TITLE
bump golang to 1.22.7

### DIFF
--- a/images/build/env
+++ b/images/build/env
@@ -1,8 +1,8 @@
 # the tag used for the final image. Update the suffix when you want
 # a new version of the image to be built.
-BUILD_IMAGE_TAG=1.22.5-1
+BUILD_IMAGE_TAG=1.22.7-1
 # the Go version used for the images.
-GO_IMAGE_VERSION=1.22.5
+GO_IMAGE_VERSION=1.22.7
 # the Kubernetes version that is used to determine which kubectl
 # to install and which kind node image to pre-load into the image.
 K8S_VERSION=1.30.0


### PR DESCRIPTION
Prepare a go 1.22.7 based build image.
