### PR TITLE
add kcp-dev/kcp-operator to Prow

### DIFF
--- a/images/build/README.md
+++ b/images/build/README.md
@@ -3,7 +3,7 @@
 This directory contains files to build `ghcr.io/kcp-dev/infra/build`, the base image used for kcp's Prow jobs. It includes the following tools:
 
 - `docker` (and `/usr/local/bin/start-docker.sh` to start it)
--  `kind` (and pre-loaded `/kindest.tar` that can be loaded into docker to have `kindest/node` available)
+- `kind` (and pre-loaded `/kindest.tar` that can be loaded into docker to have `kindest/node` available)
 - `go`
 - `git`, `jq` and `curl`
 - `kubeconform`

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -26,6 +26,7 @@ plank:
     "kcp-dev/infra": "[Full PR test history](https://public-prow.kcp.k8c.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}})"
     "kcp-dev/kcp": "[Full PR test history](https://public-prow.kcp.k8c.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}})"
     "kcp-dev/kcp-dev.github.io": "[Full PR test history](https://public-prow.kcp.k8c.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}})"
+    "kcp-dev/kcp-operator": "[Full PR test history](https://public-prow.kcp.k8c.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}})"
     "kcp-dev/kcp.io": "[Full PR test history](https://public-prow.kcp.k8c.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}})"
     "kcp-dev/logicalcluster": "[Full PR test history](https://public-prow.kcp.k8c.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}})"
     "kubestellar/kubestellar": "[Full PR test history](https://public-prow.kcp.k8c.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}})"
@@ -45,6 +46,7 @@ plank:
     "kcp-dev/infra": "https://public-prow.kcp.k8c.io/view/"
     "kcp-dev/kcp": "https://public-prow.kcp.k8c.io/view/"
     "kcp-dev/kcp-dev.github.io": "https://public-prow.kcp.k8c.io/view/"
+    "kcp-dev/kcp-operator": "https://public-prow.kcp.k8c.io/view/"
     "kcp-dev/kcp.io": "https://public-prow.kcp.k8c.io/view/"
     "kcp-dev/logicalcluster": "https://public-prow.kcp.k8c.io/view/"
     "kubestellar/kubestellar": "https://public-prow.kcp.k8c.io/view/"
@@ -129,6 +131,11 @@ plank:
         gcs_configuration:
           bucket: "s3://prow-public-data"
     - repo: "kcp-dev/kcp-dev.github.io"
+      config:
+        s3_credentials_secret: "s3-credentials-public"
+        gcs_configuration:
+          bucket: "s3://prow-public-data"
+    - repo: "kcp-dev/kcp-operator"
       config:
         s3_credentials_secret: "s3-credentials-public"
         gcs_configuration:
@@ -260,6 +267,7 @@ tide:
     # with release notes
     - repos:
         - kcp-dev/kcp
+        - kcp-dev/kcp-operator
         - kcp-dev/logicalcluster
         - kcp-dev/generic-controlplane
       labels:

--- a/prow/jobs/kcp-dev/kcp-operator/kcp-operator-presubmits.yaml
+++ b/prow/jobs/kcp-dev/kcp-operator/kcp-operator-presubmits.yaml
@@ -1,0 +1,21 @@
+presubmits:
+  kcp-dev/kcp-operator:
+    - name: pull-kcp-validate-prow-yaml
+      always_run: true
+      decorate: true
+      clone_uri: "ssh://git@github.com/kcp-dev/kcp-operator.git"
+      extra_refs:
+        - org: kcp-dev
+          repo: infra
+          base_ref: main
+          clone_uri: git@github.com:kcp-dev/infra.git
+      spec:
+        containers:
+          - image: gcr.io/k8s-prow/checkconfig:v20230919-a4926a4d02
+            command:
+              - checkconfig
+            args:
+              - -plugin-config=/home/prow/go/src/github.com/kcp-dev/infra/prow/plugins.yaml
+              - -config-path=/home/prow/go/src/github.com/kcp-dev/infra/prow/config.yaml
+              - -job-config-path=/home/prow/go/src/github.com/kcp-dev/infra/prow/jobs
+              - -prow-yaml-repo-name=$(REPO_OWNER)/$(REPO_NAME)

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -93,6 +93,10 @@ plugins:
     plugins:
       - release-note
 
+  kcp-dev/kcp-operator:
+    plugins:
+      - release-note
+
   kcp-dev/logicalcluster:
     plugins:
       - release-note


### PR DESCRIPTION
This PR fixes a stray whitespace in the README for the build image.

Oh, and it also adds the new kcp-operator repo to Prow.