### PR TITLE
Update kcp-dev/kcp-operator prow config to use correct job name

### DIFF
--- a/prow/jobs/kcp-dev/kcp-operator/kcp-operator-presubmits.yaml
+++ b/prow/jobs/kcp-dev/kcp-operator/kcp-operator-presubmits.yaml
@@ -1,6 +1,6 @@
 presubmits:
   kcp-dev/kcp-operator:
-    - name: pull-kcp-validate-prow-yaml
+    - name: pull-kcp-operator-validate-prow-yaml
       always_run: true
       decorate: true
       clone_uri: "ssh://git@github.com/kcp-dev/kcp-operator.git"


### PR DESCRIPTION
Looks like we re-used a name from kcp-dev/kcp for the Prowjob here, it should be `pull-kcp-operator-validate-prow-yaml`.