### PR TITLE
Update build image to Go 1.22.9, Helm to 3.16.3

### DIFF
--- a/images/build/Dockerfile
+++ b/images/build/Dockerfile
@@ -1,6 +1,6 @@
 ARG GO_VERSION
 
-FROM docker.io/library/golang:${GO_VERSION} as download
+FROM --platform=${BUILDPLATFORM} docker.io/library/golang:${GO_VERSION} as download
 
 # this needs to be separate from the GO_VERSION arg above because otherwise
 # it is not in scope for usage in the RUN instructions below.

--- a/images/build/env
+++ b/images/build/env
@@ -9,6 +9,6 @@ K8S_VERSION=1.30.0
 # the kind version installed into this image.
 KIND_VERSION=0.20.0
 # the Helm version installed into this image.
-HELM_VERSION=3.15.3
+HELM_VERSION=3.16.3
 # the kubeconform version installed into this image.
 KUBECONFORM_VERSION=0.6.6

--- a/images/build/env
+++ b/images/build/env
@@ -1,8 +1,8 @@
 # the tag used for the final image. Update the suffix when you want
 # a new version of the image to be built.
-BUILD_IMAGE_TAG=1.22.7-1
+BUILD_IMAGE_TAG=1.22.9-1
 # the Go version used for the images.
-GO_IMAGE_VERSION=1.22.7
+GO_IMAGE_VERSION=1.22.9
 # the Kubernetes version that is used to determine which kubectl
 # to install and which kind node image to pre-load into the image.
 K8S_VERSION=1.30.0


### PR DESCRIPTION
Bumping the Go build image to 1.22.9.

/cc @xrstf