### PR TITLE
Update build image to Go 1.22.10

### DIFF
--- a/images/build/env
+++ b/images/build/env
@@ -1,8 +1,8 @@
 # the tag used for the final image. Update the suffix when you want
 # a new version of the image to be built.
-BUILD_IMAGE_TAG=1.22.9-1
+BUILD_IMAGE_TAG=1.22.10-1
 # the Go version used for the images.
-GO_IMAGE_VERSION=1.22.9
+GO_IMAGE_VERSION=1.22.10
 # the Kubernetes version that is used to determine which kubectl
 # to install and which kind node image to pre-load into the image.
 K8S_VERSION=1.30.0


### PR DESCRIPTION
What it says on the title. Go 1.22.10 has been released recently, let's go through the usual dance to update to it.