### PR TITLE
Updated golang to 1.23.4

### DIFF
--- a/images/build/env
+++ b/images/build/env
@@ -1,8 +1,8 @@
 # the tag used for the final image. Update the suffix when you want
 # a new version of the image to be built.
-BUILD_IMAGE_TAG=1.22.10-1
+BUILD_IMAGE_TAG=1.23.4-1
 # the Go version used for the images.
-GO_IMAGE_VERSION=1.22.10
+GO_IMAGE_VERSION=1.23.4
 # the Kubernetes version that is used to determine which kubectl
 # to install and which kind node image to pre-load into the image.
 K8S_VERSION=1.30.0


### PR DESCRIPTION
This PR updates the golang toolkit to the latest tag `1.23.4`.

PS: there are other components that could be updated too, please let me know if you'd like to do it all in a single PR or piece-wise.

Fixes: https://github.com/kcp-dev/infra/issues/78