### PR TITLE
add buildah to build image

### DIFF
--- a/images/build/Dockerfile
+++ b/images/build/Dockerfile
@@ -47,6 +47,7 @@ RUN apt-get update && \
         git \
         curl \
         jq \
+        buildah \
     && rm -rf /var/lib/apt/lists/*
 
 # install Docker (and socat for tunneling the docker registry later)
@@ -58,4 +59,3 @@ RUN curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID"
     mkdir -p /etc/docker && \
     echo '{"data-root":"/docker-graph"}' | jq '.' > /etc/docker/daemon.json && \
     rm -rf /var/lib/apt/lists/*
-

--- a/images/build/env
+++ b/images/build/env
@@ -1,6 +1,6 @@
 # the tag used for the final image. Update the suffix when you want
 # a new version of the image to be built.
-BUILD_IMAGE_TAG=1.23.4-1
+BUILD_IMAGE_TAG=1.23.4-2
 # the Go version used for the images.
 GO_IMAGE_VERSION=1.23.4
 # the Kubernetes version that is used to determine which kubectl


### PR DESCRIPTION
The kcp-operator uses buildah and for the e2e jobs, it needs buildah to be available in our build image.