### PR TITLE
separate kubectl and kindest versions in build image, update kind to 0.26.0

### DIFF
--- a/images/build/Dockerfile
+++ b/images/build/Dockerfile
@@ -2,12 +2,17 @@ ARG GO_VERSION
 
 FROM --platform=${BUILDPLATFORM} docker.io/library/golang:${GO_VERSION} as download
 
-# this needs to be separate from the GO_VERSION arg above because otherwise
-# it is not in scope for usage in the RUN instructions below.
-ARG K8S_VERSION
-ARG KIND_VERSION
-ARG HELM_VERSION
-ARG KUBECONFORM_VERSION
+    # the Kubernetes version that is used to determine which kubectl to install.
+ENV KUBECTL_VERSION=1.30.0 \
+    # the kind version installed into this image.
+    # https://github.com/kubernetes-sigs/kind/releases
+    KIND_VERSION=0.26.0 \
+    # the Helm version installed into this image.
+    # https://github.com/helm/helm/releases
+    HELM_VERSION=3.16.3 \
+    # the kubeconform version installed into this image.
+    # https://github.com/yannh/kubeconform/releases
+    KUBECONFORM_VERSION=0.6.7
 
 WORKDIR /tmp
 
@@ -15,7 +20,7 @@ RUN curl --fail -L https://get.helm.sh/helm-v${HELM_VERSION}-linux-$(dpkg --prin
     chmod +x helm && \
     ./helm version --short
 
-RUN curl --fail -Lo kubectl https://dl.k8s.io/release/v${K8S_VERSION}/bin/linux/$(dpkg --print-architecture)/kubectl && \
+RUN curl --fail -Lo kubectl https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/$(dpkg --print-architecture)/kubectl && \
     chmod +x kubectl && \
     ./kubectl version --client
 

--- a/images/build/env
+++ b/images/build/env
@@ -1,14 +1,7 @@
 # the tag used for the final image. Update the suffix when you want
 # a new version of the image to be built.
-BUILD_IMAGE_TAG=1.23.4-2
+BUILD_IMAGE_TAG=1.23.4-3
 # the Go version used for the images.
-GO_IMAGE_VERSION=1.23.4
-# the Kubernetes version that is used to determine which kubectl
-# to install and which kind node image to pre-load into the image.
-K8S_VERSION=1.30.0
-# the kind version installed into this image.
-KIND_VERSION=0.20.0
-# the Helm version installed into this image.
-HELM_VERSION=3.16.3
-# the kubeconform version installed into this image.
-KUBECONFORM_VERSION=0.6.6
+GO_VERSION=1.23.4
+# the kindest image that matches the kind version above
+KINDEST_IMAGE=kindest/node:v1.32.0@sha256:c48c62eac5da28cdadcf560d1d8616cfa6783b58f0d94cf63ad1bf49600cb027

--- a/images/build/hack/build-image.sh
+++ b/images/build/hack/build-image.sh
@@ -34,15 +34,15 @@ fi
 repository=ghcr.io/kcp-dev/infra/build
 architectures="amd64 arm64"
 
-cd ./images/build
+cd images/build
 
 # read configuration file for build image
 source ./env
 
 # download kind image
 echo "Downloading kindest image to embed into image ..."
-buildah pull docker.io/kindest/node:v${K8S_VERSION}
-buildah push --format docker docker.io/kindest/node:v${K8S_VERSION} docker-archive:kindest.tar:kindest/node:v${K8S_VERSION}
+buildah pull docker.io/${KINDEST_IMAGE}
+buildah push --format docker docker.io/${KINDEST_IMAGE} docker-archive:kindest.tar
 
 image="$repository:${BUILD_IMAGE_TAG}"
 echo "Building container image $image ..."
@@ -57,12 +57,8 @@ for arch in $architectures; do
     --tag "$fullTag" \
     --arch "$arch" \
     --override-arch "$arch" \
-    --build-arg "GO_VERSION=${GO_IMAGE_VERSION}" \
-    --build-arg "K8S_VERSION=${K8S_VERSION}" \
-    --build-arg "KIND_VERSION=${KIND_VERSION}" \
-    --build-arg "HELM_VERSION=${HELM_VERSION}" \
-    --build-arg "KUBECONFORM_VERSION=${KUBECONFORM_VERSION}" \
-    --format=docker \
+    --build-arg "GO_VERSION=${GO_VERSION}" \
+    --format docker \
     .
 done
 


### PR DESCRIPTION
Exactly what I predicted would happen, did happen: Since we used the same variable for the version for kubectl and kindest, the kindest.tar inside our build image is completely out-of-sync with kind, and so kind will simply refuse to use it and load its own (1.27.0) whenever a kind cluster is created.

This PR rectifies that by separating the 2 versions and also moving most version info into the Dockerfile. Simply so that we do not need one more env, arg and --build-arg for each new tool we want to add to the Dockerfile.