### PR TITLE
Update build image to Go 1.23.5

### DIFF
--- a/images/build/README.md
+++ b/images/build/README.md
@@ -15,4 +15,4 @@ This directory contains files to build `ghcr.io/kcp-dev/infra/build`, the base i
 
 ## Updates
 
-Main component versions (Go, kind, etc) can be updated in [env](./env). Make sure to bump `BUILD_IMAGE_TAG` accordingly (the usual pattern is Go version plus a suffix that is incremented upon other version updates or addition of some tools).
+Main component versions (Go, kind, etc) can be updated in [env](./env) or the [Dockerfile](./Dockerfile) directly (from the `ENV` section). Make sure to bump `BUILD_IMAGE_TAG` accordingly (the usual pattern is Go version plus a suffix that is incremented upon other version updates or addition of some tools).

--- a/images/build/env
+++ b/images/build/env
@@ -1,7 +1,7 @@
 # the tag used for the final image. Update the suffix when you want
 # a new version of the image to be built.
-BUILD_IMAGE_TAG=1.23.4-3
+BUILD_IMAGE_TAG=1.23.5-1
 # the Go version used for the images.
-GO_VERSION=1.23.4
+GO_VERSION=1.23.5
 # the kindest image that matches the kind version above
 KINDEST_IMAGE=kindest/node:v1.32.0@sha256:c48c62eac5da28cdadcf560d1d8616cfa6783b58f0d94cf63ad1bf49600cb027


### PR DESCRIPTION
Go 1.23.5 finally released, so here we go.