### PR TITLE
Update gcsweb configuration to use s3 correctly

### DIFF
--- a/clusters/prow/manifests/prow/01-gcsweb-public.yaml
+++ b/clusters/prow/manifests/prow/01-gcsweb-public.yaml
@@ -27,10 +27,10 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
         - name: gcsweb-public
-          image: gcr.io/k8s-prow/gcsweb:v20230919-a4926a4d02
+          image: gcr.io/k8s-prow/gcsweb:v20240731-a5d9345e59
           args:
-            - -gcs-credentials-file=/etc/s3-credentials/service-account.json
-            - -b=prow-public-data
+            - -s3-credentials-file=/etc/s3-credentials/service-account.json
+            - -b=s3://prow-public-data
           ports:
             - name: http
               containerPort: 8080

--- a/clusters/prow/manifests/prow/01-gcsweb.yaml
+++ b/clusters/prow/manifests/prow/01-gcsweb.yaml
@@ -27,10 +27,10 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
         - name: gcsweb
-          image: gcr.io/k8s-prow/gcsweb:v20230919-a4926a4d02
+          image: gcr.io/k8s-prow/gcsweb:v20240731-a5d9345e59
           args:
-            - -gcs-credentials-file=/etc/s3-credentials/service-account.json
-            - -b=prow-data
+            - -s3-credentials-file=/etc/s3-credentials/service-account.json
+            - -b=s3://prow-data
           ports:
             - name: http
               containerPort: 8080

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -192,15 +192,32 @@ deck:
     # Configuring these will make an "Artifacts" link appear on the Spyglass page, linking
     # to gcsweb.
     gcs_browser_prefixes:
-      '*': https://gcsweb.kcp.k8c.io/gcs/
-      'kcp-dev/infra': https://public-gcsweb.kcp.k8c.io/gcs/
+      '*': https://gcsweb.kcp.k8c.io/s3/
+      'kcp-dev/infra': https://public-gcsweb.kcp.k8c.io/s3/
+      'kcp-dev/api-syncagent': https://public-gcsweb.kcp.k8c.io/s3/
+      'kcp-dev/apiextensions-apiserver': https://public-gcsweb.kcp.k8c.io/s3/
+      'kcp-dev/apimachinery': https://public-gcsweb.kcp.k8c.io/s3/
+      'kcp-dev/awesome-kcp': https://public-gcsweb.kcp.k8c.io/s3/
+      'kcp-dev/client-go': https://public-gcsweb.kcp.k8c.io/s3/
+      'kcp-dev/code-generator': https://public-gcsweb.kcp.k8c.io/s3/
+      'kcp-dev/controller-runtime': https://public-gcsweb.kcp.k8c.io/s3/
+      'kcp-dev/controller-runtime-example': https://public-gcsweb.kcp.k8c.io/s3/
+      'kcp-dev/enhancements': https://public-gcsweb.kcp.k8c.io/s3/
+      'kcp-dev/friends': https://public-gcsweb.kcp.k8c.io/s3/
+      'kcp-dev/helm-charts': https://public-gcsweb.kcp.k8c.io/s3/
+      'kcp-dev/kcp': https://public-gcsweb.kcp.k8c.io/s3/
+      'kcp-dev/kcp-dev.github.io': https://public-gcsweb.kcp.k8c.io/s3/
+      'kcp-dev/kcp-operator': https://public-gcsweb.kcp.k8c.io/s3/
+      'kcp-dev/kcp.io': https://public-gcsweb.kcp.k8c.io/s3/
+      'kcp-dev/logicalcluster': https://public-gcsweb.kcp.k8c.io/s3/
+      'kubestellar/kubestellar': https://public-gcsweb.kcp.k8c.io/s3/
     # required so that public periodics can point to the correct gcsweb
     # otherwise, gcsweb-public will just redirect to Google Cloud Console
     # instead of showing artifacts
     gcs_browser_prefixes_by_bucket:
-      '*': https://gcsweb.kcp.k8c.io/gcs/
-      'prow-data': https://gcsweb.kcp.k8c.io/gcs/
-      'prow-public-data': https://public-gcsweb.kcp.k8c.io/gcs/
+      '*': https://gcsweb.kcp.k8c.io/s3/
+      'prow-data': https://gcsweb.kcp.k8c.io/s3/
+      'prow-public-data': https://public-gcsweb.kcp.k8c.io/s3/
     lenses:
       - required_files:
           - started.json


### PR DESCRIPTION
We tracked down the s3 issues to a simple fact: The gcsweb we use doesn't support S3, it was more recently added.

This PR does the following things:

1. Update to the most recent gcsweb image from k8s/test-infra.
2. Configure the correct flags to use s3 credentials and serve an S3 bucket.
3. Configure the correct gcsweb prefixes into spyglass.