### PR TITLE
Upgrade MachineDeployments to Kubernetes 1.29.4

### DIFF
--- a/clusters/prow/manifests/machinedeployment-stable.yaml
+++ b/clusters/prow/manifests/machinedeployment-stable.yaml
@@ -55,4 +55,4 @@ spec:
           sshPublicKeys:
             - __SSH_PUBKEY__
       versions:
-        kubelet: 1.26.4
+        kubelet: 1.29.4

--- a/clusters/prow/manifests/machinedeployment-worker.yaml
+++ b/clusters/prow/manifests/machinedeployment-worker.yaml
@@ -64,4 +64,4 @@ spec:
           sshPublicKeys:
             - __SSH_PUBKEY__
       versions:
-        kubelet: 1.26.4
+        kubelet: 1.29.4


### PR DESCRIPTION
We downgraded our `MachineDeployments` by accident because we forgot at some point to check in our cluster upgrade work into this repository.