### PR TITLE
Protect release branches in kcp-dev org

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -329,6 +329,7 @@ branch-protection:
           - kcp-dev/kcp-admins
       include:
         - "^main$"
+        - "^release-.+$"
 
     kubestellar:
       protect: true


### PR DESCRIPTION
We should not only protect `main` branches, but all `release-` branches we have across the org.

/cc @xrstf