### PR TITLE
Configure requirement for kind labels to be on PRs

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -296,7 +296,7 @@ tide:
         - do-not-merge/work-in-progress
         - needs-rebase
 
-    # with release notes
+    # with release-note and needs-kind plugins
     - repos:
         - kcp-dev/api-syncagent
         - kcp-dev/kcp
@@ -314,6 +314,7 @@ tide:
         - do-not-merge/invalid-owners-file
         - do-not-merge/release-note-label-needed
         - do-not-merge/work-in-progress
+        - do-not-merge/needs-kind
         - needs-rebase
 
 branch-protection:

--- a/prow/labels.yaml
+++ b/prow/labels.yaml
@@ -142,6 +142,12 @@ default:
       target: prs
       prowPlugin: wip
       addedBy: prow
+    - color: e11d21
+      description: Indicates a PR lacks a `kind/foo` label and requires one.
+      name: do-not-merge/needs-kind
+      target: prs
+      prowPlugin: require-matching-label
+      addedBy: prow
     - color: 7057ff
       description: Denotes an issue ready for a new contributor, according to the "help wanted" guidelines.
       name: 'good first issue'

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -92,14 +92,17 @@ plugins:
   kcp-dev/kcp:
     plugins:
       - release-note
+      - require-matching-label
 
   kcp-dev/api-syncagent:
     plugins:
       - release-note
+      - require-matching-label
 
   kcp-dev/kcp-operator:
     plugins:
       - release-note
+      - require-matching-label
 
   kcp-dev/logicalcluster:
     plugins:
@@ -108,6 +111,7 @@ plugins:
   kcp-dev/multicluster-provider:
     plugins:
       - release-note
+      - require-matching-label
 
   kcp-dev/generic-controlplane:
     plugins:
@@ -136,6 +140,33 @@ plugins:
       - trigger
       - verify-owners # verifies format of OWNERS file
       - wip
+
+require_matching_label:
+  - missing_label: do-not-merge/needs-kind
+    org: kcp-dev
+    repo: kcp
+    prs: true
+    regexp: ^kind/
+  - missing_label: do-not-merge/needs-kind
+    org: kcp-dev
+    repo: api-syncagent
+    prs: true
+    regexp: ^kind/
+  - missing_label: do-not-merge/needs-kind
+    org: kcp-dev
+    repo: kcp-operator
+    prs: true
+    regexp: ^kind/
+  - missing_label: do-not-merge/needs-kind
+    org: kcp-dev
+    repo: kcp-operator
+    prs: true
+    regexp: ^kind/
+  - missing_label: do-not-merge/needs-kind
+    org: kcp-dev
+    repo: multicluster-provider
+    prs: true
+    regexp: ^kind/
 
 external_plugins:
   kcp-dev:


### PR DESCRIPTION
This PR is towards https://github.com/kcp-dev/kcp/issues/3351, making `kind/` labels mandatory on our main repositories.

Before this can be merged, all repositories should have their templates updated and #96 has to be fixed.

/hold