### PR TITLE
Add IaC module for Oracle Cloud prow cluster

### DIFF
--- a/iac/oci-prow-worker/.env.example
+++ b/iac/oci-prow-worker/.env.example
@@ -1,0 +1,3 @@
+export AWS_ACCESS_KEY_ID=''
+export AWS_SECRET_ACCESS_KEY=''
+export AWS_ENDPOINT_URL_S3='https://<ID>.compat.objectstorage.us-sanjose-1.oraclecloud.com'

--- a/iac/oci-prow-worker/.gitignore
+++ b/iac/oci-prow-worker/.gitignore
@@ -1,0 +1,8 @@
+# Terraform folder
+.terraform
+# Make sure to not allow checking in tfvars by mistake
+*.tfvars
+# Environment variables are often stored in this file
+.env
+
+kubeconfig

--- a/iac/oci-prow-worker/.terraform.lock.hcl
+++ b/iac/oci-prow-worker/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/oracle/oci" {
+  version     = "6.33.0"
+  constraints = "6.33.0"
+  hashes = [
+    "h1:Iuo9RepfXpjr0gM/HKv9TzXcd0joq0pyFc7UrvqtuCk=",
+    "zh:014dd2366fe7bac2a99581438a19fee611475c44d9aaf15e3325d6b49e4a1461",
+    "zh:1282483324fe982d6c1d6d460b5aaa90bc11466d88018b2003bc3c5fcb66b99d",
+    "zh:1effcaec5f8ae351a9e783c1ce8cb183bd6fe5435850fdf2aa157ab4cbf2d259",
+    "zh:2f9507fafb216077554d00e2f91f9e0e157a6656bc5862332007af967093d432",
+    "zh:3242d27dc530e9443178eda4ec6a5fbfe46a740cbed538166fa8ea4044d6f5fe",
+    "zh:3c454bb32b41011da3de5b0da28a0c7ee0f4786a82a16d74bf87f6f41f4d3ff6",
+    "zh:54c2f4bd5c6cdaa29190913dd0a50d74caf9a5618d33b1de569dcae83266a718",
+    "zh:5665fb4fa93d1c6c4b94cac9cf71dea92e51f559dbfe31cde3ed7bc56d6e1ec6",
+    "zh:624e6cc4ac6d8f7d9d0b7be40196d4a18ed1e9776576938f12fad869ab3e31c5",
+    "zh:7c560a4b6d46c163b8399e2c5033fe4bf43d85eb091896af4c2134937c17973e",
+    "zh:976016a1f2bee2b83bfeed79c63f8aef2abd7a72c469095b01d109a871eb9eb8",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:b4fa0627816d748e8b3b802335a511f08d3f8fb036f52db141d7610419cc2f37",
+    "zh:fc58bc9449035aa887a75a74dd7685e2811e6518d29270d67193002d3c94b5dd",
+    "zh:ffd814a8383505beeaf182aa7de94c5e4575936eb195f429d5a1da805968b470",
+  ]
+}

--- a/iac/oci-prow-worker/Makefile
+++ b/iac/oci-prow-worker/Makefile
@@ -1,0 +1,16 @@
+OPENTOFU_CLI ?= tofu
+
+init:
+	$(OPENTOFU_CLI) init
+
+fmt:
+	$(OPENTOFU_CLI) fmt
+
+plan:
+	$(OPENTOFU_CLI) plan
+
+apply:
+	$(OPENTOFU_CLI) apply
+
+kubeconfig:
+	$(OPENTOFU_CLI) output -show-sensitive -json | jq -r '.cluster.value.kubeconfig' > kubeconfig

--- a/iac/oci-prow-worker/README.md
+++ b/iac/oci-prow-worker/README.md
@@ -1,0 +1,41 @@
+# oci-prow-cluster
+
+This directory deploys the `oci-prow-cluster` OKE cluster in OCI (Oracle Cloud) via [OpenTofu](https://opentofu.org). A shared state is stored in a OCI storage bucket, please make sure to use that.
+
+<!-- TODO: Usually, this code shouldn't be executed directly but run by Prow. -->
+
+## Required Environment Variables
+
+The following environment variables are required before running any `make` targets:
+
+- `AWS_ACCESS_KEY_ID`: Needs to be the key ID for a [Customer Secret Key](https://docs.oracle.com/en-us/iaas/Content/Identity/Tasks/managingcredentials.htm#Working2) to access OCI's S3-compatible storage buckets.
+- `AWS_SECRET_ACCESS_KEY`: Needs to be the secret for a [Customer Secret Key](https://docs.oracle.com/en-us/iaas/Content/Identity/Tasks/managingcredentials.htm#Working2) to access OCI's S3-compatible storage buckets.
+- `AWS_ENDPOINT_URL_S3`: Needs to be `https://<object namespace>.compat.objectstorage.us-sanjose-1.oraclecloud.com`. Replace `<object namespace>` with the namespace displayed on the bucket (see OCI Console for this information).
+
+## Running OpenTofu
+
+Easiest way to run OpenTofu locally is to create a `.env` file with the required environment variables and then run `make` commands. For example, create a file `.env` (or see [.env.example](./.env.example)):
+
+```bash
+export AWS_ACCESS_KEY_ID=xxxxxxxxxxxxxxx
+export AWS_SECRET_ACCESS_KEY=xxxxxxxxxxxxxxxxxxxx
+export AWS_ENDPOINT_URL_S3=https://xxxxxxxxxxxx.compat.objectstorage.us-sanjose-1.oraclecloud.com
+export TF_LOG=DEBUG
+```
+
+Create `terraform.tfvars` file with the following content:
+
+```hcl
+oci_tenant_ocid          = "ocid1.tenancy.oc1..xxxxxxxxxxxxxxxxxxx"
+oci_compartment_ocid     = "ocid1.compartment.oc1..xxxxxxxxxxxxxxxxxxx"
+oci_region               = "us-sanjose-1"
+node_pool_ssh_public_key = "ssh-rsa "
+oci_auth_type            = "SecurityToken"
+oci_config_file_profile  = "KCP"
+```
+
+Install `oci` cli and run `oci session authenticate` to get the `oci_config_file` and `oci_profile` values.
+
+Set up environment variables by running `source .env`.
+
+Then run `make init` and `make plan` to see the changes that will be applied. If everything looks good, run `make apply`.

--- a/iac/oci-prow-worker/cluster.tf
+++ b/iac/oci-prow-worker/cluster.tf
@@ -1,0 +1,69 @@
+resource "oci_containerengine_cluster" "prow" {
+  name               = "oci-prow-worker"
+  kubernetes_version = var.kubernetes_version
+
+  cluster_pod_network_options {
+    cni_type = "OCI_VCN_IP_NATIVE"
+  }
+
+  endpoint_config {
+    is_public_ip_enabled = true
+    subnet_id            = oci_core_subnet.prow_worker_cluster.id
+  }
+
+  options {
+    service_lb_subnet_ids = [oci_core_subnet.prow_worker_cluster.id]
+  }
+
+  compartment_id = var.oci_compartment_ocid
+  vcn_id         = oci_core_vcn.prow.id
+}
+
+data "oci_containerengine_cluster_kube_config" "prow" {
+  cluster_id = oci_containerengine_cluster.prow.id
+}
+
+resource "oci_containerengine_node_pool" "prow_worker" {
+  cluster_id     = oci_containerengine_cluster.prow.id
+  compartment_id = var.oci_compartment_ocid
+
+  kubernetes_version = var.kubernetes_version
+  name               = "prow-worker"
+  ssh_public_key     = var.node_pool_ssh_public_key
+
+  # this matches t3.2xlarge sizings.
+  node_shape = "VM.Standard.A1.Flex"
+  node_shape_config {
+    memory_in_gbs = 32
+    ocpus         = 8
+  }
+
+
+  # Using image Oracle-Linux-8.x-<date>
+  # Find image OCID for your region from https://docs.oracle.com/iaas/images/
+  # For now aarch64 latest k/k 1.31 image is used.
+  node_source_details {
+    image_id    = "ocid1.image.oc1.us-sanjose-1.aaaaaaaadsern2rllfhao7uyg3t5gafy7xh63apdywrcs3hpryrgnpbgh7sa"
+    source_type = "image"
+  }
+
+  node_config_details {
+    size = var.node_pool_worker_size
+
+    # create placement_configs for each availability domain.
+    # There happens to be only a single one in us-sanjose-1.
+    dynamic "placement_configs" {
+      for_each = data.oci_identity_availability_domains.availability_domains.availability_domains
+      content {
+        availability_domain = placement_configs.value.name
+        subnet_id           = oci_core_subnet.prow_worker_nodes.id
+      }
+    }
+
+    node_pool_pod_network_option_details {
+      cni_type       = "OCI_VCN_IP_NATIVE"
+      pod_nsg_ids    = []
+      pod_subnet_ids = [oci_core_subnet.prow_worker_nodes.id]
+    }
+  }
+}

--- a/iac/oci-prow-worker/network.tf
+++ b/iac/oci-prow-worker/network.tf
@@ -1,0 +1,79 @@
+resource "oci_core_vcn" "prow" {
+  cidr_block     = "10.0.0.0/16"
+  compartment_id = var.oci_compartment_ocid
+  display_name   = "Prow Network"
+}
+
+resource "oci_core_internet_gateway" "prow" {
+  compartment_id = var.oci_compartment_ocid
+  display_name   = "Prow Internet Gateway"
+  vcn_id         = oci_core_vcn.prow.id
+}
+
+resource "oci_core_route_table" "prow_worker" {
+  compartment_id = var.oci_compartment_ocid
+  vcn_id         = oci_core_vcn.prow.id
+  display_name   = "Prow Worker Route Table"
+
+  route_rules {
+    destination       = "0.0.0.0/0"
+    destination_type  = "CIDR_BLOCK"
+    network_entity_id = oci_core_internet_gateway.prow.id
+  }
+}
+
+resource "oci_core_security_list" "node_api_access" {
+  compartment_id = var.oci_compartment_ocid
+  vcn_id         = oci_core_vcn.prow.id
+  display_name   = "Prow Worker Kubernetes API Access"
+
+  # Allow access from anywhere to Kubernetes API port.
+  ingress_security_rules {
+    protocol = "6" # TCP
+
+    source      = "0.0.0.0/0"
+    source_type = "CIDR_BLOCK"
+
+    tcp_options {
+      min = 6443
+      max = 6443
+    }
+  }
+
+  # Allow node pool CIDR to access port for proxymux.
+  ingress_security_rules {
+    protocol = "6" # TCP
+
+    source      = "10.0.64.0/18"
+    source_type = "CIDR_BLOCK"
+
+    tcp_options {
+      min = 12250
+      max = 12250
+    }
+  }
+
+}
+
+resource "oci_core_subnet" "prow_worker_nodes" {
+  availability_domain = null
+  cidr_block          = "10.0.64.0/18"
+  compartment_id      = var.oci_compartment_ocid
+  vcn_id              = oci_core_vcn.prow.id
+
+  security_list_ids = [oci_core_vcn.prow.default_security_list_id]
+  route_table_id    = oci_core_route_table.prow_worker.id
+  display_name      = "Prow Nodes/Pods Subnet"
+}
+
+resource "oci_core_subnet" "prow_worker_cluster" {
+  availability_domain = null
+  cidr_block          = "10.0.10.0/24"
+  compartment_id      = var.oci_compartment_ocid
+  vcn_id              = oci_core_vcn.prow.id
+
+  security_list_ids = [oci_core_vcn.prow.default_security_list_id, oci_core_security_list.node_api_access.id]
+  route_table_id    = oci_core_route_table.prow_worker.id
+  dhcp_options_id   = oci_core_vcn.prow.default_dhcp_options_id
+  display_name      = "Prow Cluster Subnet"
+}

--- a/iac/oci-prow-worker/outputs.tf
+++ b/iac/oci-prow-worker/outputs.tf
@@ -1,0 +1,6 @@
+output "cluster" {
+  value = {
+    kubeconfig = data.oci_containerengine_cluster_kube_config.prow.content
+  }
+  sensitive = true
+}

--- a/iac/oci-prow-worker/provider.tf
+++ b/iac/oci-prow-worker/provider.tf
@@ -1,0 +1,11 @@
+provider "oci" {
+  tenancy_ocid        = var.oci_tenant_ocid
+  region              = var.oci_region
+  auth                = var.oci_auth_type
+  config_file_profile = var.oci_config_file_profile
+}
+
+data "oci_identity_availability_domains" "availability_domains" {
+  compartment_id = var.oci_tenant_ocid
+}
+

--- a/iac/oci-prow-worker/terraform.tf
+++ b/iac/oci-prow-worker/terraform.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    oci = {
+      source  = "oracle/oci"
+      version = "6.33.0"
+    }
+  }
+
+  # make sure to set AWS_ENDPOINT_URL_S3 to 'https://<object namespace>.compat.objectstorage.us-sanjose-1.oraclecloud.com'.
+  backend "s3" {
+    bucket = "kcp-opentofu-state"
+    region = "us-sanjose-1"
+    key    = "ci-prow-worker/tf.tfstate"
+
+    skip_region_validation      = true
+    skip_credentials_validation = true
+    skip_requesting_account_id  = true
+    use_path_style              = true
+    skip_metadata_api_check     = true
+  }
+}

--- a/iac/oci-prow-worker/variables.tf
+++ b/iac/oci-prow-worker/variables.tf
@@ -1,0 +1,46 @@
+variable "oci_tenant_ocid" {
+  type = string
+}
+
+variable "oci_compartment_ocid" {
+  type = string
+}
+
+/*
+variable "oci_user_ocid" {
+  type = string
+}
+
+variable "oci_private_key" {
+  type      = string
+  sensitive = true
+}
+*/
+
+variable "oci_region" {
+  type = string
+}
+
+variable "node_pool_ssh_public_key" {
+  type = string
+}
+
+variable "node_pool_worker_size" {
+  type    = number
+  default = 3
+}
+
+variable "kubernetes_version" {
+  type    = string
+  default = "v1.31.1"
+}
+
+variable "oci_config_file_profile" {
+  type    = string
+  default = "DEFAULT"
+}
+
+variable "oci_auth_type" {
+  type    = string
+  default = "SecurityToken"
+}


### PR DESCRIPTION
This PR adds OpenTofu files to maintain our Oracle Cloud prow cluster. For now, I'm not adding automation for it, but we should probably do that as next step.

This PR does the following:

- Set up networking on OCI.
- Create a `oci-prow-worker` OKE cluster. 
- Add a three node node pool with 8 CPUs / 32GB RAM per node.

The SSH key is a key I specifically generated to be shared, so please let me know if you need it.

I'd like to merge this code for now and iterate on it, eventually moving automation to the prow control plane cluster (?).