### PR TITLE
Don't set --orgs on label-sync job

### DIFF
--- a/prow/jobs/kcp-dev/infra/infra-periodics.yaml
+++ b/prow/jobs/kcp-dev/infra/infra-periodics.yaml
@@ -19,7 +19,6 @@ periodics:
         args:
         - --config=/home/prow/go/src/github.com/kcp-dev/infra/prow/labels.yaml
         - --confirm=true
-        - --orgs=kcp-dev
         - --only=kcp-dev/kcp,kcp-dev/api-syncagent,kcp-dev/kcp-operator,kcp-dev/multicluster-provider,kcp-dev/infra,kcp-dev/helm-charts,kcp-dev/kcp.io,kcp-dev/generic-controlplane,kcp-dev/client-go,kcp-dev/code-generator,kcp-dev/apimachinery,kcp-dev/controller-runtime,kcp-dev/logicalcluster
         - --token=/etc/oauth-token/token
         - --endpoint=http://ghproxy.prow.svc.cluster.local


### PR DESCRIPTION
`--orgs` and `--only` conflicts. Only one should be set.

/cc @xrstf 