### PR TITLE
Add presubmit job to kcp-dev/kcp to test OCI worker cluster

### DIFF
--- a/prow/jobs/kcp-dev/kcp/kcp-presubmits-oci.yaml
+++ b/prow/jobs/kcp-dev/kcp/kcp-presubmits-oci.yaml
@@ -1,0 +1,31 @@
+presubmits:
+  kcp-dev/kcp:
+    # test job to run e2e test on OCI worker cluster (ARM)
+    - name: pull-kcp-test-e2e-sharded-oci
+      decorate: true
+      optional: true
+      always_run: false
+      clone_uri: "https://github.com/kcp-dev/kcp"
+      labels:
+        preset-goproxy: "true"
+      cluster: oci-prow-worker
+      spec:
+        containers:
+          - image: ghcr.io/kcp-dev/infra/build:1.23.7-1
+            command:
+              - ./hack/run-with-prow.sh
+              - ./hack/run-with-prometheus.sh
+              - make
+              - test-e2e-sharded-minimal
+            env:
+              - name: SUITES
+                value: control-plane
+              - name: USE_GOTESTSUM
+                value: '1'
+              - name: KUBE_CACHE_MUTATION_DETECTOR
+                value: '1'
+            resources:
+              requests:
+                memory: 6Gi
+                cpu: 4
+


### PR DESCRIPTION
This is a temporary presubmit job so we can start running jobs on OCI.

/cc @xrstf 