### PR TITLE
Make docker registry environment variable in Prow optional

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -353,6 +353,7 @@ presets:
           configMapKeyRef:
             name: cluster-config
             key: DOCKER_REGISTRY_MIRROR_ADDR
+            optional: true
     volumeMounts:
       - name: scratch
         mountPath: /scratch


### PR DESCRIPTION
Our oci-prow-worker cluster doesn't have a docker registry mirror, so jobs cannot start there. This makes the environment variable optional.

/cc @xrstf 