### PR TITLE
Fix typo in kcp-dev branch protection, remove kubestellar

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -438,7 +438,7 @@ branch-protection:
           include:
             - "^main$"
             - "^release-.+$"
-        logialcluster:
+        logicalcluster:
           protect: true
           required_status_checks:
             contexts:
@@ -450,18 +450,6 @@ branch-protection:
           include:
             - "^main$"
             - "^release-.+$"
-
-    kubestellar:
-      protect: true
-      required_status_checks:
-        contexts:
-          - dco
-      restrictions:
-        users: []
-        teams:
-          - kubestellar/kubestellar-admins
-      include:
-        - "^main$"
 
 presets:
   ################################################################


### PR DESCRIPTION
The branchprotector job is failing because of two reasons:

1. I added a typo in #107.
2. There are several kubestellar repositories that the bot does not appear to have access to, and thus branch protection is failing.

Since KubeStellar is migrating off the shared Prow instance, I'm removing kubestellar from the configuration to unblock the job succeeding.