### PR TITLE
Fix repository name for kcp-dev/apimachinery branch protection

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -426,7 +426,7 @@ branch-protection:
           include:
             - "^main$"
             - "^release-.+$"
-        api-machinery:
+        apimachinery:
           protect: true
           required_status_checks:
             contexts:


### PR DESCRIPTION
A follow up to #108, apparently I added another typo that went unnoticed.