### PR TITLE
Configure branch protection for "kcp-" branches on some repositories

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -414,6 +414,7 @@ branch-protection:
           include:
             - "^main$"
             - "^release-.+$"
+            - "^kcp-.+$"
         code-generator:
           protect: true
           required_status_checks:
@@ -426,6 +427,7 @@ branch-protection:
           include:
             - "^main$"
             - "^release-.+$"
+            - "^kcp-.+$"
         apimachinery:
           protect: true
           required_status_checks:
@@ -438,6 +440,18 @@ branch-protection:
           include:
             - "^main$"
             - "^release-.+$"
+            - "^kcp-.+$"
+        kubernetes:
+          protect: true
+          required_status_checks:
+            contexts:
+              - dco
+          restrictions:
+            users: []
+            teams:
+              - kcp-dev/kcp-admins
+          include:
+            - "^kcp-.+$"
         logicalcluster:
           protect: true
           required_status_checks:


### PR DESCRIPTION
As a follow-up to previous PRs, this creates additional branch protection for branches with the `kcp-` prefix, which we are using or about to use for the following repositories:

- kcp-dev/kubernetes
- kcp-dev/code-generator
- kcp-dev/apimachinery
- kcp-dev/client-go