### PR TITLE
Remove branch protection config for kcp-dev/kubernetes

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -431,17 +431,18 @@ branch-protection:
             - "^main$"
             - "^release-.+$"
             - "^kcp-.+$"
-        kubernetes:
-          protect: true
-          required_status_checks:
-            contexts:
-              - dco
-          restrictions:
-            users: []
-            teams:
-              - kcp-dev/kcp-admins
-          include:
-            - "^kcp-.+$"
+        # TODO: get kcp-ci-bot permissions to manage kcp-dev/kubernetes branches
+        # kubernetes:
+        #   protect: true
+        #   required_status_checks:
+        #     contexts:
+        #       - dco
+        #   restrictions:
+        #     users: []
+        #     teams:
+        #       - kcp-dev/kcp-admins
+        #   include:
+        #     - "^kcp-.+$"
         logicalcluster:
           protect: true
           required_status_checks:


### PR DESCRIPTION
The branch protection job in Prow is currently failing because it is missing permissions to access branch protection information on kcp-dev/kubernetes:

```json
{"component":"branchprotector","file":"sigs.k8s.io/prow/cmd/branchprotector/protect.go:101","func":"main.(*Errors).add","level":"info","msg":"update kcp-dev: update kubernetes: [update kcp-1.28-pre.1 from protected=false: get current branch protection: getting branch protection 404: Not Found, update kcp-1.31-baseline from protected=false: get current branch protection: getting branch protection 404: Not Found, update kcp-1.31.6 from protected=false: get current branch protection: getting branch protection 404: Not Found, update kcp-1.32-baseline from protected=false: get current branch protection: getting branch protection 404: Not Found, update kcp-1.32.3 from protected=false: get current branch protection: getting branch protection 404: Not Found, update kcp-feature-logical-clusters-1.24-v3 from protected=false: get current branch protection: getting branch protection 404: Not Found, update kcp-1.28-baseline-1 from protected=false: get current branch protection: getting branch protection 404: Not Found, update kcp-1.28 from protected=false: get current branch protection: getting branch protection 404: Not Found, update kcp-1.30 from protected=false: get current branch protection: getting branch protection 404: Not Found, update kcp-1.30.3 from protected=false: get current branch protection: getting branch protection 404: Not Found, update kcp-1.32-pre.1 from protected=false: get current branch protection: getting branch protection 404: Not Found, update kcp-1.26-baseline from protected=false: get current branch protection: getting branch protection 404: Not Found, update kcp-1.26-split from protected=false: get current branch protection: getting branch protection 404: Not Found, update kcp-1.28-pre.2 from protected=false: get current branch protection: getting branch protection 404: Not Found, update kcp-1.28-pre.3 from protected=false: get current branch protection: getting branch protection 404: Not Found, update kcp-1.26 from protected=false: get current branch protection: getting branch protection 404: Not Found, update kcp-1.28-1 from protected=false: get current branch protection: getting branch protection 404: Not Found, update kcp-1.31-pre.1 from protected=false: get current branch protection: getting branch protection 404: Not Found, update kcp-1.31.0 from protected=false: get current branch protection: getting branch protection 404: Not Found]","severity":"info","time":"2025-05-06T11:01:13Z"}

```

We should disable it for now so branch protection can run.