### PR TITLE
Several updates to the OCI prow cluster

### DIFF
--- a/iac/oci-prow-worker/.terraform.lock.hcl
+++ b/iac/oci-prow-worker/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.opentofu.org/oracle/oci" {
   constraints = "6.33.0"
   hashes = [
     "h1:Iuo9RepfXpjr0gM/HKv9TzXcd0joq0pyFc7UrvqtuCk=",
+    "h1:JhJfXRCL0BN1YZcw+ejqvHmWGvx4p6CymfOBO+8X9xY=",
     "zh:014dd2366fe7bac2a99581438a19fee611475c44d9aaf15e3325d6b49e4a1461",
     "zh:1282483324fe982d6c1d6d460b5aaa90bc11466d88018b2003bc3c5fcb66b99d",
     "zh:1effcaec5f8ae351a9e783c1ce8cb183bd6fe5435850fdf2aa157ab4cbf2d259",

--- a/iac/oci-prow-worker/README.md
+++ b/iac/oci-prow-worker/README.md
@@ -39,3 +39,15 @@ Install `oci` cli and run `oci session authenticate` to get the `oci_config_file
 Set up environment variables by running `source .env`.
 
 Then run `make init` and `make plan` to see the changes that will be applied. If everything looks good, run `make apply`.
+
+## Manual Modifications
+
+### Manual Route Table
+
+The route table `ocid1.routetable.oc1.us-sanjose-1.aaaaaaaaguv25vmwy4j5k2hunwcmjx6tpbbfnmuhzmxowstl76mj4ui7zpxq` was created manually to troubleshoot connectivity issues. It looks like the provider does not allow resource import.
+
+### Node Disk Grow
+
+Reference: https://www.ateam-oracle.com/post/oke-node-sizing-for-very-large-container-images
+
+I (@embik) couldn't find a way to automate this step, so I had to manually adjust the node pool via the UI.

--- a/iac/oci-prow-worker/addons.tf
+++ b/iac/oci-prow-worker/addons.tf
@@ -1,0 +1,15 @@
+resource "oci_containerengine_addon" "cluster_autoscaler" {
+  addon_name                       = "ClusterAutoscaler"
+  cluster_id                       = oci_containerengine_cluster.prow.id
+  remove_addon_resources_on_delete = true
+
+  configurations {
+    key   = "authType"
+    value = "instance"
+  }
+
+  configurations {
+    key   = "nodes"
+    value = "${var.cluster_autoscaler_min}:${var.cluster_autoscaler_max}:${oci_containerengine_node_pool.prow_worker.id}"
+  }
+}

--- a/iac/oci-prow-worker/cluster.tf
+++ b/iac/oci-prow-worker/cluster.tf
@@ -2,6 +2,8 @@ resource "oci_containerengine_cluster" "prow" {
   name               = "oci-prow-worker"
   kubernetes_version = var.kubernetes_version
 
+  type = "ENHANCED_CLUSTER"
+
   cluster_pod_network_options {
     cni_type = "OCI_VCN_IP_NATIVE"
   }
@@ -31,10 +33,10 @@ resource "oci_containerengine_node_pool" "prow_worker" {
   name               = "prow-worker"
   ssh_public_key     = var.node_pool_ssh_public_key
 
-  # this matches t3.2xlarge sizings.
+  # this matches t3.xlarge sizings.
   node_shape = "VM.Standard.A1.Flex"
   node_shape_config {
-    memory_in_gbs = 32
+    memory_in_gbs = 16
     ocpus         = 8
   }
 
@@ -43,8 +45,9 @@ resource "oci_containerengine_node_pool" "prow_worker" {
   # Find image OCID for your region from https://docs.oracle.com/iaas/images/
   # For now aarch64 latest k/k 1.31 image is used.
   node_source_details {
-    image_id    = "ocid1.image.oc1.us-sanjose-1.aaaaaaaadsern2rllfhao7uyg3t5gafy7xh63apdywrcs3hpryrgnpbgh7sa"
-    source_type = "image"
+    image_id                = "ocid1.image.oc1.us-sanjose-1.aaaaaaaadsern2rllfhao7uyg3t5gafy7xh63apdywrcs3hpryrgnpbgh7sa"
+    source_type             = "image"
+    boot_volume_size_in_gbs = 200
   }
 
   node_config_details {

--- a/iac/oci-prow-worker/network.tf
+++ b/iac/oci-prow-worker/network.tf
@@ -22,14 +22,39 @@ resource "oci_core_route_table" "prow_worker" {
   }
 }
 
-resource "oci_core_security_list" "node_api_access" {
+# Rules based on https://docs.oracle.com/en-us/iaas/Content/ContEng/Concepts/contengnetworkconfig.htm#securitylistconfig.
+
+resource "oci_core_security_list" "node_network" {
   compartment_id = var.oci_compartment_ocid
   vcn_id         = oci_core_vcn.prow.id
-  display_name   = "Prow Worker Kubernetes API Access"
+  display_name   = "Prow Worker Cross-Node Access"
+
+  # Allow access from node/pod CIDR to all TCP ports.
+  ingress_security_rules {
+    protocol = "6" # TCP
+
+    source      = "10.0.64.0/18"
+    source_type = "CIDR_BLOCK"
+  }
+
+  # Allow access from node/pod CIDR to all UDP ports.
+  ingress_security_rules {
+    protocol = "17" # UDP
+
+    source      = "10.0.64.0/18"
+    source_type = "CIDR_BLOCK"
+  }
+}
+
+resource "oci_core_security_list" "kubernetes_api" {
+  compartment_id = var.oci_compartment_ocid
+  vcn_id         = oci_core_vcn.prow.id
+  display_name   = "Kubernetes API Security List"
 
   # Allow access from anywhere to Kubernetes API port.
   ingress_security_rules {
-    protocol = "6" # TCP
+    protocol  = "6" # TCP
+    stateless = false
 
     source      = "0.0.0.0/0"
     source_type = "CIDR_BLOCK"
@@ -42,7 +67,8 @@ resource "oci_core_security_list" "node_api_access" {
 
   # Allow node pool CIDR to access port for proxymux.
   ingress_security_rules {
-    protocol = "6" # TCP
+    protocol  = "6" # TCP
+    stateless = false
 
     source      = "10.0.64.0/18"
     source_type = "CIDR_BLOCK"
@@ -52,7 +78,17 @@ resource "oci_core_security_list" "node_api_access" {
       max = 12250
     }
   }
+
+  # Path Discovery.
+  ingress_security_rules {
+    protocol  = "1"
+    stateless = false
+
+    source      = "10.0.64.0/18"
+    source_type = "CIDR_BLOCK"
+  }
 }
+
 
 resource "oci_core_security_list" "control_plane_node_access" {
   compartment_id = var.oci_compartment_ocid
@@ -80,8 +116,8 @@ resource "oci_core_subnet" "prow_worker_nodes" {
   compartment_id      = var.oci_compartment_ocid
   vcn_id              = oci_core_vcn.prow.id
 
-  security_list_ids = [oci_core_vcn.prow.default_security_list_id, oci_core_security_list.control_plane_node_access.id]
-  route_table_id    = oci_core_route_table.prow_worker.id
+  security_list_ids = [oci_core_vcn.prow.default_security_list_id, oci_core_security_list.control_plane_node_access.id, oci_core_security_list.node_network.id]
+  route_table_id    = "ocid1.routetable.oc1.us-sanjose-1.aaaaaaaaguv25vmwy4j5k2hunwcmjx6tpbbfnmuhzmxowstl76mj4ui7zpxq"
   display_name      = "Prow Nodes/Pods Subnet"
 }
 
@@ -91,7 +127,7 @@ resource "oci_core_subnet" "prow_worker_cluster" {
   compartment_id      = var.oci_compartment_ocid
   vcn_id              = oci_core_vcn.prow.id
 
-  security_list_ids = [oci_core_vcn.prow.default_security_list_id, oci_core_security_list.node_api_access.id]
+  security_list_ids = [oci_core_vcn.prow.default_security_list_id, oci_core_security_list.kubernetes_api.id]
   route_table_id    = oci_core_route_table.prow_worker.id
   dhcp_options_id   = oci_core_vcn.prow.default_dhcp_options_id
   display_name      = "Prow Cluster Subnet"

--- a/iac/oci-prow-worker/variables.tf
+++ b/iac/oci-prow-worker/variables.tf
@@ -30,6 +30,16 @@ variable "node_pool_worker_size" {
   default = 3
 }
 
+variable "cluster_autoscaler_min" {
+  type    = number
+  default = 1
+}
+
+variable "cluster_autoscaler_max" {
+  type    = number
+  default = 5
+}
+
 variable "kubernetes_version" {
   type    = string
   default = "v1.31.1"


### PR DESCRIPTION
This commits changes I made to get the OCI prow cluster functional and into a good state. Unfortunately some things were done by hand, so things are a little messy, but this still applies so that's what's important.

* Create boot volumes with 200GB
* Update security lists
* Use hand-crafted route table
* Upgrade cluster to enhanced
* Install cluster-autoscaler