### PR TITLE
kcp-dev/api-syncagent: use same buildah version as presubmit job

### DIFF
--- a/prow/jobs/kcp-dev/api-syncagent/api-syncagent-postsubmits.yaml
+++ b/prow/jobs/kcp-dev/api-syncagent/api-syncagent-postsubmits.yaml
@@ -12,7 +12,7 @@ postsubmits:
         - ^v\d+\..*
       spec:
         containers:
-          - image: quay.io/containers/buildah:v1.30.0
+          - image: quay.io/containers/buildah:v1.38.0
             command:
               - hack/ci/build-image.sh
             # docker-in-docker needs privileged mode


### PR DESCRIPTION
The in-repository job uses buildah 1.38.0, but the postsubmit uses 1.30.0:

https://github.com/kcp-dev/api-syncagent/blob/3c8f5f0b4dadc695195d8815f1cedec2229b20b6/.prow.yaml#L57

Let's fix that and align the two versions.