### PR TITLE
kcp-dev/kcp: apply v0.28.0 milestone to merges into main

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -145,6 +145,10 @@ require_matching_label:
     prs: true
     regexp: ^kind/
 
+milestone_applier:
+  kcp-dev/kcp:
+    main: "v0.28.0"
+
 external_plugins:
   kcp-dev:
     - name: needs-rebase


### PR DESCRIPTION
I would like to propose that we start tracking PRs merged into `main` via GitHub milestones. Doing this mid-release-cycle obviously means it will be an incomplete list, but starting from the next minor release we could have this information.