### PR TITLE
bump build image to Go 1.23.10, 1.24.4

### DIFF
--- a/images/build/go-1.23/env
+++ b/images/build/go-1.23/env
@@ -1,7 +1,7 @@
 # the tag used for the final image. Update the suffix when you want
 # a new version of the image to be built.
-BUILD_IMAGE_TAG=1.23.9-1
+BUILD_IMAGE_TAG=1.23.10-1
 # the Go version used for the images.
-GO_VERSION=1.23.9
+GO_VERSION=1.23.10
 # the kindest image that matches the kind version above
 KINDEST_IMAGE=kindest/node:v1.32.0@sha256:c48c62eac5da28cdadcf560d1d8616cfa6783b58f0d94cf63ad1bf49600cb027

--- a/images/build/go-1.24/env
+++ b/images/build/go-1.24/env
@@ -1,7 +1,7 @@
 # the tag used for the final image. Update the suffix when you want
 # a new version of the image to be built.
-BUILD_IMAGE_TAG=1.24.3-1
+BUILD_IMAGE_TAG=1.24.4-1
 # the Go version used for the images.
-GO_VERSION=1.24.3
+GO_VERSION=1.24.4
 # the kindest image that matches the kind version above
 KINDEST_IMAGE=kindest/node:v1.32.2@sha256:f226345927d7e348497136874b6d207e0b32cc52154ad8323129352923a3142f


### PR DESCRIPTION
New Go releases contain several CVE fixes.