### PR TITLE
Update to Go 1.24.5 and 1.23.11

### DIFF
--- a/images/build/go-1.23/env
+++ b/images/build/go-1.23/env
@@ -1,7 +1,7 @@
 # the tag used for the final image. Update the suffix when you want
 # a new version of the image to be built.
-BUILD_IMAGE_TAG=1.23.10-1
+BUILD_IMAGE_TAG=1.23.11-1
 # the Go version used for the images.
-GO_VERSION=1.23.10
+GO_VERSION=1.23.11
 # the kindest image that matches the kind version above
 KINDEST_IMAGE=kindest/node:v1.32.0@sha256:c48c62eac5da28cdadcf560d1d8616cfa6783b58f0d94cf63ad1bf49600cb027

--- a/images/build/go-1.24/Dockerfile
+++ b/images/build/go-1.24/Dockerfile
@@ -3,13 +3,13 @@ ARG GO_VERSION
 FROM --platform=${TARGETPLATFORM} docker.io/library/golang:${GO_VERSION} as download
 
     # the Kubernetes version that is used to determine which kubectl to install.
-ENV KUBECTL_VERSION=1.32.5 \
+ENV KUBECTL_VERSION=1.32.7 \
     # the kind version installed into this image.
     # https://github.com/kubernetes-sigs/kind/releases
-    KIND_VERSION=0.27.0 \
+    KIND_VERSION=0.29.0 \
     # the Helm version installed into this image.
     # https://github.com/helm/helm/releases
-    HELM_VERSION=3.17.2 \
+    HELM_VERSION=3.18.4 \
     # the kubeconform version installed into this image.
     # https://github.com/yannh/kubeconform/releases
     KUBECONFORM_VERSION=0.7.0

--- a/images/build/go-1.24/env
+++ b/images/build/go-1.24/env
@@ -1,7 +1,7 @@
 # the tag used for the final image. Update the suffix when you want
 # a new version of the image to be built.
-BUILD_IMAGE_TAG=1.24.4-1
+BUILD_IMAGE_TAG=1.24.5-1
 # the Go version used for the images.
-GO_VERSION=1.24.4
+GO_VERSION=1.24.5
 # the kindest image that matches the kind version above
-KINDEST_IMAGE=kindest/node:v1.32.2@sha256:f226345927d7e348497136874b6d207e0b32cc52154ad8323129352923a3142f
+KINDEST_IMAGE=kindest/node:v1.32.5@sha256:e3b2327e3a5ab8c76f5ece68936e4cafaa82edf58486b769727ab0b3b97a5b0d


### PR DESCRIPTION
To prepare the next release cycle, this bumps our build images. Particularly 1.24 gets a bunch of updates all around so we can bump kcp's `main` branch to it.