### PR TITLE
Register kcp-dev/publishing-bot with Prow

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -31,6 +31,7 @@ plank:
     "kcp-dev/kcp.io": "[Full PR test history](https://public-prow.kcp.k8c.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}})"
     "kcp-dev/logicalcluster": "[Full PR test history](https://public-prow.kcp.k8c.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}})"
     "kcp-dev/multicluster-provider": "[Full PR test history](https://public-prow.kcp.k8c.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}})"
+    "kcp-dev/publishing-bot": "[Full PR test history](https://public-prow.kcp.k8c.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}})"
 
   job_url_prefix_config:
     "*": https://prow.kcp.k8c.io/view/
@@ -52,6 +53,7 @@ plank:
     "kcp-dev/kcp.io": "https://public-prow.kcp.k8c.io/view/"
     "kcp-dev/logicalcluster": "https://public-prow.kcp.k8c.io/view/"
     "kcp-dev/multicluster-provider": "https://public-prow.kcp.k8c.io/view/"
+    "kcp-dev/publishing-bot": "https://public-prow.kcp.k8c.io/view/"
 
   default_decoration_config_entries:
     # default config
@@ -167,6 +169,11 @@ plank:
         s3_credentials_secret: "s3-credentials-public"
         gcs_configuration:
           bucket: "s3://prow-public-data"
+    - repo: "kcp-dev/publishing-bot"
+      config:
+        s3_credentials_secret: "s3-credentials-public"
+        gcs_configuration:
+          bucket: "s3://prow-public-data"
 
 in_repo_config:
   enabled:
@@ -211,6 +218,7 @@ deck:
       'kcp-dev/kcp.io': https://public-gcsweb.kcp.k8c.io/s3/
       'kcp-dev/logicalcluster': https://public-gcsweb.kcp.k8c.io/s3/
       'kcp-dev/multicluster-provider': https://public-gcsweb.kcp.k8c.io/s3/
+      'kcp-dev/publishing-bot': https://public-gcsweb.kcp.k8c.io/s3/
     # required so that public periodics can point to the correct gcsweb
     # otherwise, gcsweb-public will just redirect to Google Cloud Console
     # instead of showing artifacts
@@ -275,6 +283,7 @@ tide:
         - kcp-dev/infra
         - kcp-dev/kcp-dev.github.io
         - kcp-dev/kcp.io
+        - kcp-dev/publishing-bot
       labels:
         - lgtm
         - approved
@@ -454,6 +463,18 @@ branch-protection:
               - kcp-dev/kcp-admins
           include:
             - "^main$"
+            - "^release-.+$"
+        publishing-bot:
+          protect: true
+          required_status_checks:
+            contexts:
+              - dco
+          restrictions:
+            users: []
+            teams:
+              - kcp-dev/kcp-admins
+          include:
+            - "^master$"
             - "^release-.+$"
 
 presets:

--- a/prow/jobs/kcp-dev/infra/infra-periodics.yaml
+++ b/prow/jobs/kcp-dev/infra/infra-periodics.yaml
@@ -19,7 +19,7 @@ periodics:
         args:
         - --config=/home/prow/go/src/github.com/kcp-dev/infra/prow/labels.yaml
         - --confirm=true
-        - --only=kcp-dev/kcp,kcp-dev/api-syncagent,kcp-dev/kcp-operator,kcp-dev/multicluster-provider,kcp-dev/infra,kcp-dev/helm-charts,kcp-dev/kcp.io,kcp-dev/generic-controlplane,kcp-dev/client-go,kcp-dev/code-generator,kcp-dev/apimachinery,kcp-dev/controller-runtime,kcp-dev/logicalcluster
+        - --only=kcp-dev/kcp,kcp-dev/api-syncagent,kcp-dev/kcp-operator,kcp-dev/multicluster-provider,kcp-dev/infra,kcp-dev/helm-charts,kcp-dev/kcp.io,kcp-dev/generic-controlplane,kcp-dev/client-go,kcp-dev/code-generator,kcp-dev/apimachinery,kcp-dev/controller-runtime,kcp-dev/logicalcluster,kcp-dev/publishing-bot
         - --token=/etc/oauth-token/token
         - --endpoint=http://ghproxy.prow.svc.cluster.local
         - --endpoint=https://api.github.com

--- a/prow/jobs/kcp-dev/publishing-bot/publishing-bot-presubmits.yaml
+++ b/prow/jobs/kcp-dev/publishing-bot/publishing-bot-presubmits.yaml
@@ -1,0 +1,22 @@
+presubmits:
+  kcp-dev/publishing-bot:
+    - name: pull-publishing-bot-validate-prow-yaml
+      cluster: prow
+      always_run: true
+      decorate: true
+      clone_uri: "ssh://git@github.com/kcp-dev/publishing-bot.git"
+      extra_refs:
+        - org: kcp-dev
+          repo: infra
+          base_ref: main
+          clone_uri: git@github.com:kcp-dev/infra.git
+      spec:
+        containers:
+          - image: gcr.io/k8s-prow/checkconfig:v20230919-a4926a4d02
+            command:
+              - checkconfig
+            args:
+              - -plugin-config=/home/prow/go/src/github.com/kcp-dev/infra/prow/plugins.yaml
+              - -config-path=/home/prow/go/src/github.com/kcp-dev/infra/prow/config.yaml
+              - -job-config-path=/home/prow/go/src/github.com/kcp-dev/infra/prow/jobs
+              - -prow-yaml-repo-name=$(REPO_OWNER)/$(REPO_NAME)


### PR DESCRIPTION
This PR is supposed to register [`kcp-dev/publishing-bot`](https://github.com/kcp-dev/publishing-bot) with Prow so that we have CI in that repo. Jobs will be added later.

/assign @xrstf 