### PR TITLE
Update build images to Go 1.24.8 and 1.25.2

### DIFF
--- a/images/build/go-1.24/env
+++ b/images/build/go-1.24/env
@@ -1,7 +1,7 @@
 # the tag used for the final image. Update the suffix when you want
 # a new version of the image to be built.
-BUILD_IMAGE_TAG=1.24.6-1
+BUILD_IMAGE_TAG=1.24.8-1
 # the Go version used for the images.
-GO_VERSION=1.24.6
+GO_VERSION=1.24.8
 # the kindest image that matches the kind version above
 KINDEST_IMAGE=kindest/node:v1.32.5@sha256:e3b2327e3a5ab8c76f5ece68936e4cafaa82edf58486b769727ab0b3b97a5b0d

--- a/images/build/go-1.25/env
+++ b/images/build/go-1.25/env
@@ -1,7 +1,7 @@
 # the tag used for the final image. Update the suffix when you want
 # a new version of the image to be built.
-BUILD_IMAGE_TAG=1.25.0-1
+BUILD_IMAGE_TAG=1.25.2-1
 # the Go version used for the images.
-GO_VERSION=1.25.0
+GO_VERSION=1.25.2
 # the kindest image that matches the kind version above
 KINDEST_IMAGE=kindest/node:v1.33.1@sha256:050072256b9a903bd914c0b2866828150cb229cea0efe5892e2b644d5dd3b34f


### PR DESCRIPTION
New Go versions with a long list of security fixes. Worth updating. See https://groups.google.com/d/msgid/golang-announce/459c470d.BAAAB6Txh8AAAAAAAAAAA-p9MGAAAYKKSQYAAAAAADE8OwBo5WD-%40mailjet.com for the full details.