### PR TITLE
set blocker_label in Prow

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -267,6 +267,8 @@ tide:
   merge_method:
     kcp-dev: merge
 
+  blocker_label: tide/merge-blocker
+
   queries:
     # no release notes
     - repos:


### PR DESCRIPTION
This is so that no merges happen in monorepo'ed repos like client-go or apimachinery.