### PR TITLE
deploy Sextant to visualize kcp-dev release branches

### DIFF
--- a/clusters/prow/hack/ci/deploy.sh
+++ b/clusters/prow/hack/ci/deploy.sh
@@ -65,6 +65,24 @@ kubectl replace --filename manifests/prowjob-crd.yaml
 echo "Installing Tide restarter..."
 kubectl apply --filename manifests/tide-restarter.yaml
 
+echo "Installing Sextant..."
+
+# Sextant relies on a sextant-github-token Secret that has to be created manually.
+kubectl apply --filename manifests/sextant.yaml
+
+# deploy the Sextant config
+(
+  cd manifests/sextant
+  kubectl --namespace release-branches create configmap sextant-config \
+    --from-file config.yaml \
+    --from-file extract-dockerfile-image-tag.sh \
+    --from-file kcp-operator-extract-kcp.sh \
+    --dry-run=client -o yaml | kubectl apply --filename -
+)
+
+# rotate Sextant to make the new config take effect
+kubectl --namespace release-branches rollout restart deployment sextant
+
 ###########################################################
 # ensure these deployments are scheduled on the stable nodes, so
 # that when zero workers are running, these essential services still

--- a/clusters/prow/manifests/release-branch-reporter.yaml
+++ b/clusters/prow/manifests/release-branch-reporter.yaml
@@ -1,0 +1,147 @@
+#
+# This deploys https://codeberg.org/xrstf/sextant to generate a single HTML
+# file detailing the status of the various release branches for kcp repositories.
+#
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: release-branches
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sextant-cache
+  namespace: release-branches
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sextant
+  namespace: release-branches
+spec:
+  selector:
+    app: sextant
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sextant
+  namespace: release-branches
+  labels:
+    app: sextant
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: sextant
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: sextant
+    spec:
+      containers:
+        # The webserver that serves the generated HTML file.
+        - image: nginx:1.29.7-alpine
+          name: nginx
+          ports:
+            - containerPort: 80
+          resources:
+            limits:
+              cpu: 500m
+              memory: 64Mi
+            requests:
+              cpu: 10m
+              memory: 32Mi
+          volumeMounts:
+            - name: scratch
+              mountPath: /usr/share/nginx/html
+
+        # The sidecar that continuously updates the HTML file with the latest status of the release branches.
+        - image: codeberg.org/xrstf/sextant:0.5.3-alpine
+          name: sextant
+          command: [/bin/sh]
+          args:
+            - -c
+            - |
+              while true; do
+                sextant \
+                  --format html \
+                  --config /config/config.yaml \
+                  --cache-directory /cache > /scratch/index.html
+
+                sleep $SEXTANT_INTERVAL
+              done
+          env:
+            - name: SEXTANT_INTERVAL
+              value: 60m
+            - name: GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: sextant-github-token
+                  key: token
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 10m
+              memory: 32Mi
+          volumeMounts:
+            - name: config
+              mountPath: /config
+            - name: cache
+              mountPath: /cache
+            - name: scratch
+              mountPath: /scratch
+      volumes:
+        - name: config
+          configMap:
+            name: sextant-config
+        - name: cache
+          persistentVolumeClaim:
+            claimName: sextant-cache
+        - name: scratch
+          emptyDir: {}
+
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: sextant
+  namespace: release-branches
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+    ingress.kubernetes.io/force-ssl-redirect: "true"
+    kubernetes.io/ingress.class: nginx
+spec:
+  rules:
+    - host: release-branches.kcp.k8c.io
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: sextant
+                port:
+                  number: 80
+  tls:
+    - hosts:
+        - release-branches.kcp.k8c.io
+      secretName: sextant-tls

--- a/clusters/prow/manifests/sextant/config.yaml
+++ b/clusters/prow/manifests/sextant/config.yaml
@@ -1,0 +1,118 @@
+repositories:
+  - owner: kcp-dev
+    name: kcp
+    displayName: kcp
+    releaseBranches:
+      pattern: release-\d\.\d+$
+      max: 3
+    pullRequests:
+      maxDisplay: 5
+    fields:
+      - id: go
+        label: Go
+        location: column
+        file:
+          paths:
+            - Dockerfile
+          filterCommand:
+            - /bin/sh
+            - /config/extract-dockerfile-image-tag.sh
+          allowedEnv: [PATH]
+
+      - id: clientgo
+        label: Kube
+        location: column
+        goDependency:
+          dependency: k8s.io/client-go
+
+  - owner: kcp-dev
+    name: kcp-operator
+    displayName: kcp Operator
+    releaseBranches:
+      pattern: release-\d\.\d+$
+      max: 3
+    pullRequests:
+      maxDisplay: 5
+    fields:
+      - id: go
+        label: Go
+        location: column
+        file:
+          paths:
+            - Dockerfile
+          filterCommand:
+            - /bin/sh
+            - /config/extract-dockerfile-image-tag.sh
+          allowedEnv: [PATH]
+      - id: kcp
+        label: kcp
+        location: column
+        file:
+          paths:
+            - internal/resources/resources.go
+          filterCommand:
+            - /bin/sh
+            - /config/kcp-operator-extract-kcp.sh
+          allowedEnv: [PATH]
+
+
+  - owner: kcp-dev
+    name: api-syncagent
+    displayName: API Sync Agent
+    releaseBranches:
+      pattern: release-\d\.\d+$
+      max: 3
+    pullRequests:
+      maxDisplay: 5
+    fields:
+      - id: go
+        label: Go
+        location: column
+        file:
+          paths:
+            - Dockerfile
+          filterCommand:
+            - /bin/sh
+            - /config/extract-dockerfile-image-tag.sh
+          allowedEnv: [PATH]
+
+  - owner: kcp-dev
+    name: init-agent
+    displayName: Init Agent
+    releaseBranches:
+      pattern: release-\d\.\d+$
+      max: 3
+    pullRequests:
+      maxDisplay: 5
+    fields:
+      - id: go
+        label: Go
+        location: column
+        file:
+          paths:
+            - Dockerfile
+          filterCommand:
+            - /bin/sh
+            - /config/extract-dockerfile-image-tag.sh
+          allowedEnv: [PATH]
+
+  - owner: kube-bind
+    name: kube-bind
+    displayName: kube-bind
+    releaseBranches:
+      pattern: release-\d\.\d+$
+      max: 3
+    pullRequests:
+      maxDisplay: 5
+    fields:
+      - id: go
+        label: Go
+        location: column
+        file:
+          paths:
+            - Dockerfile
+          filterCommand:
+            - /bin/sh
+            - /config/extract-dockerfile-image-tag.sh
+          allowedEnv: [PATH]
+          extraEnv: {IMAGE: golang}

--- a/clusters/prow/manifests/sextant/extract-dockerfile-image-tag.sh
+++ b/clusters/prow/manifests/sextant/extract-dockerfile-image-tag.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+
+# takes a Dockerfile and returns the version of either the first image or the first $IMAGE image
+
+if [ -z "$IMAGE" ]; then
+  cat | grep "FROM " | head -n1 | sed -E 's/ (as|AS) [a-z-]+$//' | cut -d':' -f 2
+else
+  cat | grep "FROM " | sed -E 's/ (as|AS) [a-z-]+$//' | grep "$IMAGE:" | head -n1 | cut -d':' -f 2
+fi

--- a/clusters/prow/manifests/sextant/kcp-operator-extract-kcp.sh
+++ b/clusters/prow/manifests/sextant/kcp-operator-extract-kcp.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+
+# takes the resources.go from the kcp-operator and returns the ImageTag value
+
+tag="$(grep -E 'ImageTag\s*=' | sed -E "s#\s*ImageTag\s*=\s*\"(.+?)\"#\1#")"
+
+if ! [[ $tag =~ ^v ]]; then
+  tag="$(echo "$tag" | cut -c1-8)…"
+fi
+
+echo -n "$tag"


### PR DESCRIPTION
This powers https://release-branches.kcp.k8c.io/, as discussed in today's kcp community call.