### PR TITLE
bump build image to Go 1.26.3 / 1.25.10

### DIFF
--- a/images/build/go-1.25/env
+++ b/images/build/go-1.25/env
@@ -1,8 +1,8 @@
 # the tag used for the final image. Update the suffix when you want
 # a new version of the image to be built.
-BUILD_IMAGE_TAG=1.25.9-1
+BUILD_IMAGE_TAG=1.25.10-1
 # the Go version used for the images.
-GO_VERSION=1.25.9
+GO_VERSION=1.25.10
 # the kindest image that matches the kind version above
 # INFO(embik): this is pinned due to extensive debugging in https://github.com/kcp-dev/kcp-operator/pull/104
 # showing that importing images seems to be broken with newer node images (at least 1.32.5, but 1.34.0 [newest

--- a/images/build/go-1.26/env
+++ b/images/build/go-1.26/env
@@ -1,8 +1,8 @@
 # the tag used for the final image. Update the suffix when you want
 # a new version of the image to be built.
-BUILD_IMAGE_TAG=1.26.2-1
+BUILD_IMAGE_TAG=1.26.3-1
 # the Go version used for the images.
-GO_VERSION=1.26.2
+GO_VERSION=1.26.3
 # the kindest image that matches the kind version above
 # INFO(embik): this is pinned due to extensive debugging in https://github.com/kcp-dev/kcp-operator/pull/104
 # showing that importing images seems to be broken with newer node images (at least 1.32.5, but 1.34.0 [newest


### PR DESCRIPTION
It's that time of month again.